### PR TITLE
ci: run framework suite in CI + add Phase 9 daily health workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,20 @@ jobs:
         run: |
           pytest --cov=. --cov-report=xml
 
+  framework-verify:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify exo-cortex framework
+        run: |
+          # Runs the phase verification suite (Core Loop, Memory, Multi-Runtime,
+          # Knowledge Depth, Operational, Coherence, Automation, Hermes, Dev Loop).
+          # GitHub sets CI=true, so run-all.sh auto-skips Phase 7 (validates the live
+          # VPS1 host, not an ephemeral runner). All in-scope checks must pass.
+          bash tests/run-all.sh
+
   security-scan:
     runs-on: ubuntu-latest
     needs: test
@@ -75,7 +89,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    needs: [lint, test, security-scan]
+    needs: [lint, test, framework-verify, security-scan]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/daily-health.yml
+++ b/.github/workflows/daily-health.yml
@@ -1,0 +1,168 @@
+name: Daily Health Check
+
+# Phase 9 (Real Integrations) — "gh-aw or equivalent scheduled issue creation for
+# daily health". L3 sensing: produces a phone-readable GitHub Issue each morning.
+#
+# This is the GitHub-Actions-native counterpart to deploy/vps1/health-check.sh.
+# Live-host signals (Docker, NanoClaw, Telegram, Supermemory tokens) come from the
+# last health-status.json snapshot the VPS1 health check commits; repo-side signals
+# (framework suite, wiki staleness, routing-log recency) are computed fresh here.
+# Spec: workflows/daily-health.md
+
+on:
+  schedule:
+    # 5:00am UTC daily — a morning read for the operator's phone.
+    - cron: '0 5 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  health:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need history so wiki staleness (last-commit age) can be computed.
+          fetch-depth: 0
+
+      - name: Run framework verification suite
+        id: suite
+        continue-on-error: true
+        run: |
+          # CI=true makes run-all.sh skip Phase 7 (live VPS host).
+          OUTPUT=$(CI=true bash tests/run-all.sh 2>&1) || true
+          echo "pass=$(echo "$OUTPUT" | grep -c '  ✓' || true)" >> "$GITHUB_OUTPUT"
+          echo "fail=$(echo "$OUTPUT" | grep -c '  ✗' || true)" >> "$GITHUB_OUTPUT"
+
+      - name: Compose and publish health issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const cp = require('child_process');
+
+            const date = new Date().toISOString().split('T')[0];
+
+            const readJson = (p) => {
+              try { return JSON.parse(fs.readFileSync(p, 'utf8')); }
+              catch (e) { return null; }
+            };
+            const sh = (cmd) => {
+              try { return cp.execSync(cmd, { encoding: 'utf8' }).trim(); }
+              catch (e) { return ''; }
+            };
+
+            // --- Framework suite (computed fresh in the previous step) ---
+            const suitePass = parseInt('${{ steps.suite.outputs.pass }}' || '0');
+            const suiteFail = parseInt('${{ steps.suite.outputs.fail }}' || '0');
+            const suiteStatus = suiteFail === 0 ? '✅' : '❌';
+
+            // --- Last committed VPS health snapshot ---
+            const health = readJson('memory/state/health-status.json');
+            const devloop = readJson('memory/state/dev-loop-status.json');
+
+            const emoji = (s) => s === 'ok' || s === 'healthy' ? '✅'
+              : s === 'warning' ? '⚠️' : (s ? '❌' : '❔');
+
+            let systemRows = '| _no health-status.json snapshot found_ | ❔ | |';
+            let snapshotNote = '';
+            if (health) {
+              snapshotNote = `_Live-host rows reflect the last VPS snapshot (${health.timestamp})._`;
+              const sys = health.system || {};
+              const svc = health.services || {};
+              systemRows = [
+                `| Overall | ${emoji(health.overall)} | ${health.overall || 'unknown'} |`,
+                `| Disk | ${emoji(sys.disk_status)} | ${sys.disk_percent ?? '?'}% |`,
+                `| Memory | ${emoji(sys.memory_status)} | ${sys.memory_percent ?? '?'}% |`,
+                `| Docker | ${emoji(svc.docker_status)} | ${svc.docker_running ?? '?'} containers |`,
+                `| NanoClaw | ${svc.nanoclaw_up ? '✅' : '❌'} | ${svc.nanoclaw_up ? 'up' : 'down'} |`,
+                `| Claude auth | ${svc.claude_auth ? '✅' : '❔'} | ${svc.claude_auth || 'unknown'} |`,
+              ].join('\n');
+            }
+
+            // --- Wiki staleness (repo-side, fresh) ---
+            const wikis = ['docs/centaurion-wiki', 'docs/aob-wiki', 'docs/builderbee-wiki'];
+            const wikiRows = wikis.map(w => {
+              const when = sh(`git log -1 --format=%cr -- ${w}`) || 'never';
+              const days = parseInt(sh(`git log -1 --format=%ct -- ${w}`) || '0');
+              const ageDays = days ? Math.floor((Date.now()/1000 - days) / 86400) : 999;
+              const flag = ageDays > 7 ? '⚠️ stale' : '✅';
+              return `| ${w.replace('docs/','')} | ${when} | ${flag} |`;
+            }).join('\n');
+
+            // --- Routing-log recency (repo-side, fresh) ---
+            let routingLine = 'No routing-log.jsonl found.';
+            try {
+              const lines = fs.readFileSync('memory/state/routing-log.jsonl', 'utf8')
+                .split('\n').filter(l => l.trim() && l.includes('"timestamp"'));
+              const last = lines.length ? JSON.parse(lines[lines.length - 1]) : null;
+              const dayAgo = Date.now() - 24*3600*1000;
+              const recent = lines.filter(l => {
+                try { return new Date(JSON.parse(l).timestamp).getTime() >= dayAgo; }
+                catch (e) { return false; }
+              }).length;
+              routingLine = `Entries: ${lines.length} total, ${recent} in last 24h. Last: ${last ? last.timestamp : 'n/a'}.`;
+            } catch (e) {}
+
+            const devloopLine = devloop
+              ? `${devloop.status} (Phase ${devloop.phase}, ${devloop.tests_remaining} tests remaining) — ${devloop.timestamp}`
+              : 'No dev-loop-status.json snapshot.';
+
+            const title = `[centaurion-health] ${date}`;
+            const body = [
+              `## Daily Health — ${date}`,
+              '',
+              '### Framework Suite (fresh)',
+              `${suiteStatus} **${suitePass} passed, ${suiteFail} failed** (CI scope — Phase 7/VPS excluded)`,
+              '',
+              '### System / Services',
+              '| Component | Status | Notes |',
+              '|-----------|--------|-------|',
+              systemRows,
+              '',
+              snapshotNote,
+              '',
+              '### Dev Loop',
+              `- ${devloopLine}`,
+              '',
+              '### Wiki Freshness (stale if > 7 days)',
+              '| Wiki | Last commit | Status |',
+              '|------|-------------|--------|',
+              wikiRows,
+              '',
+              '### Routing (24h)',
+              `- ${routingLine}`,
+              '',
+              '---',
+              '*Centaurion daily health — GitHub Actions L3 sensing. VPS-live checks come from the last committed snapshot.*',
+            ].join('\n');
+
+            // Close older health issues (single rolling report).
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'daily',
+              state: 'open',
+            });
+            for (const issue of existing.data) {
+              if (issue.title.startsWith('[centaurion-health]') && issue.title !== title) {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  state: 'closed',
+                  state_reason: 'completed',
+                });
+              }
+            }
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: title,
+              body: body,
+              labels: ['report', 'daily'],
+            });

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -45,7 +45,7 @@
 - [x] NanoClaw renamed from OpenClaw across deploy/
 - [ ] Syncthing between VPS1 and VPS2 (P2P wiki sync)
 - [ ] Nova actually scanning via Telegram (NanoClaw → Cortex routing)
-- [ ] gh-aw or equivalent scheduled issue creation for daily health
+- [x] gh-aw or equivalent scheduled issue creation for daily health (`.github/workflows/daily-health.yml`)
 - [ ] InfraNodus MCP for gap analysis (or equivalent)
 - [ ] Wiki repos as separate GitHub repos (not just docs/ subdirectories)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All changes to the Centaurion exo-cortex, with real dates and deliverables.
 
+## CI/CD Hardening + Phase 9 start (2026-06-19)
+- **CI/CD pipeline** now validates the deployed app (root Dockerfile = React/Vite + FastAPI), enforces a real security gate (bandit blocking on our code, safety advisory), and added a first pytest suite. Build job repointed off the non-deployed legacy server; live at centaurion.onrender.com. (PR #62)
+- **`.github/workflows/ci.yml`**: new `framework-verify` job runs the phase verification suite (`tests/run-all.sh`) on every push/PR — GitHub CI now checks ~309 framework invariants, not just smoke tests. Blocks `build`.
+- **`tests/run-all.sh`**: auto-skips Phase 7 (live VPS1 host) when `CI=true`.
+- **`tests/verify-core-loop.sh`**: R10.1/R10.2 now skip intentionally gitignored per-operator files (onboarding-state.json, BASELINE-*.md) — fixes CI false-positives while still validating real broken references.
+- **Phase 9:** `.github/workflows/daily-health.yml` created — scheduled daily GitHub Issue with framework-suite status, last VPS health snapshot, dev-loop status, wiki freshness, and routing recency (satisfies the "gh-aw workflow creating issues" Definition-of-Done item).
+
 ## Phase 8 — Operational Automation (2026-04-16)
 - **deploy/vps1/centaurion-dev-loop.sh** rewritten: lock file prevents concurrent runs, log rotation (14 days), execution metrics, dev-loop-status.json output
 - **deploy/vps1/weekly-review.sh** created: L2 sensing runner, uses `claude -p`, generates structured weekly comparison, cron-installable (Mondays 7am CET)

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -49,7 +49,15 @@ run_phase 3 "Multi-Runtime & Feedback" "tests/verify-multi-runtime.sh"
 run_phase 4 "Knowledge Depth" "tests/verify-knowledge-depth.sh"
 run_phase 5 "Operational Workflows" "tests/verify-operational.sh"
 run_phase 6 "Cross-Venture Coherence" "tests/verify-coherence.sh"
-run_phase 7 "Production Deployment" "tests/verify-production.sh"
+# Phase 7 validates the live VPS1 host (cron, NanoClaw, deployment) and cannot pass
+# on an ephemeral CI runner. GitHub Actions sets CI=true; skip it there. It still runs
+# locally and on VPS1 (where the dev loop and health check cover production).
+if [ "${CI:-}" = "true" ]; then
+  echo ""
+  echo "⏭  Phase 7 (Production Deployment): skipped in CI (validates live VPS1 host)"
+else
+  run_phase 7 "Production Deployment" "tests/verify-production.sh"
+fi
 run_phase 8 "Operational Automation" "tests/verify-automation.sh"
 run_phase 10 "Hermes Integration" "tests/verify-hermes-integration.sh"
 

--- a/tests/verify-core-loop.sh
+++ b/tests/verify-core-loop.sh
@@ -316,6 +316,12 @@ CLAUDE_PATHS=$(grep -oE '(identity|framework|agents|skills|memory|workflows)/[A-
 R10_1_OK=true
 for path in $CLAUDE_PATHS; do
   if [ ! -f "$REPO_ROOT/$path" ]; then
+    # Skip intentionally gitignored per-operator/runtime files (e.g. onboarding-state.json,
+    # identity/BASELINE-*.md). They exist on the operator's host but are absent by design in
+    # fresh clones / CI, so a missing gitignored path is not a broken reference.
+    if git -C "$REPO_ROOT" check-ignore -q "$path" 2>/dev/null; then
+      continue
+    fi
     fail "R10.1: CLAUDE.md references non-existent file: $path"
     R10_1_OK=false
   fi
@@ -331,6 +337,10 @@ AGENTS_PATHS=$(grep -oE '(identity|framework|agents|skills|memory|workflows)/[A-
 R10_2_OK=true
 for path in $AGENTS_PATHS; do
   if [ ! -f "$REPO_ROOT/$path" ]; then
+    # Skip intentionally gitignored per-operator/runtime files (absent by design in CI).
+    if git -C "$REPO_ROOT" check-ignore -q "$path" 2>/dev/null; then
+      continue
+    fi
     fail "R10.2: AGENTS.md references non-existent file: $path"
     R10_2_OK=false
   fi


### PR DESCRIPTION
## Summary

Two follow-ups from the CI/CD work, both selected for implementation:

1. **Wire the framework verification suite into CI** — GitHub Actions now validates the exo-cortex itself (~309 checks), not just the 8 pytest smoke tests.
2. **Start Phase 9 (Real Integrations)** — add the scheduled daily health-check GitHub workflow (the roadmap's "gh-aw workflow creating issues" Definition-of-Done item).

## 1. `framework-verify` job

- New `ci.yml` job runs `tests/run-all.sh` on every push/PR and **gates `build`**.
- `run-all.sh` **auto-skips Phase 7 when `CI=true`** — Phase 7 validates the live VPS1 host (cron, NanoClaw, `/root` paths) and can't pass on an ephemeral runner. It still runs locally and on VPS1.
- `verify-core-loop.sh` R10.1/R10.2 now **skip intentionally gitignored per-operator files** (`onboarding-state.json`, `BASELINE-*.md`). These exist on the operator's host but are absent by design in a fresh clone, so a missing *gitignored* path is not a broken reference. This removes CI false-positives **without** weakening the real broken-link checks (non-ignored missing files still fail).

Result in CI mode locally: **309 passed, 0 failed (exit 0)**.

## 2. Phase 9 — `daily-health.yml`

A scheduled (daily 05:00 UTC + manual) GitHub Issue, the Actions-native counterpart to `deploy/vps1/health-check.sh`, following the `workflows/daily-health.md` spec:
- **Fresh repo-side signals:** framework-suite pass/fail, wiki staleness (stale if >7 days), routing-log recency (entries in last 24h).
- **Live-host signals** from the last committed `health-status.json` snapshot (disk/memory/Docker/NanoClaw/Claude-auth) + `dev-loop-status.json`.
- Single rolling report: closes older `[centaurion-health]` issues; labels `report`, `daily`.

## Verification
- CI-mode suite: `CI=true bash tests/run-all.sh` → **309/309, exit 0**.
- `pytest` → 8 passed; `bandit -r backend main.py -ll` → clean.
- Both workflows: valid YAML; `daily-health.yml` github-script → `node --check` passes.

## Not included (deferred, per your call)
- Secrets-in-history purge (R35.3 — needs history rewrite + force-push + key rotation).
- Phase 9 infra-bound items (Syncthing, Nova-on-Telegram, InfraNodus MCP, wikis-as-separate-repos) require the live VPS/Telegram environment and can't be completed from CI — ready to do when run there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JeETwQfNjm7eXmDvgpHa4K)_