### PR TITLE
fix(dashboard): bake real state snapshot into the Render image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,13 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY backend/ ./backend/
 COPY frontend/ ./frontend/
 
+# Real Centaurion state read by the live dashboard (backend/api/live_data.py resolves
+# REPO_ROOT to /app). A read-only snapshot baked at build time — refreshes each deploy.
+# Verified secret-free: memory/supermemory.json is an env-ref, not a real key.
+COPY memory/ ./memory/
+COPY .github/ ./.github/
+COPY .planning/ ./.planning/
+
 WORKDIR /app/frontend
 RUN npm install && npm run build
 


### PR DESCRIPTION
Production dashboard returned all-zeros — the Dockerfile copied only `backend/` + `frontend/`, so `live_data.py` found no state at `/app/memory`. This COPYs `memory/`, `.github/`, `.planning/` into the image (148K total, verified secret-free). Container-layout simulation confirms real data: total_operations=11, success_rate=90, system_health=95, phase 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)