### PR TITLE
feat(phase-9): PT-7 InfraNodus gap-analysis integration scaffold

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -100,6 +100,9 @@
 ### P3 — Phase 9 infra remainder
 - [ ] **PT-7** Syncthing (VPS1↔VPS2 wiki sync), InfraNodus MCP (gap analysis),
   wikis-as-separate-repos. **Done when:** Phase 9 DoD infra items met.
+  - InfraNodus scaffold added (`memory/infranodus.json` + `deploy/infranodus/`) —
+    needs `INFRANODUS_API_KEY` to activate. MCP config + HTTP-API runbook + gap-analysis
+    skill wiring all in place; flip to live by setting the key on the host.
 
 **Sequencing:** PT-1 (clean footing) → PT-2/3/4 (system is real & live) → PT-5/6 (polish & reliability) → PT-7 (infra).
 

--- a/deploy/infranodus/README.md
+++ b/deploy/infranodus/README.md
@@ -1,0 +1,108 @@
+# InfraNodus — Gap Analysis Integration (Phase 9 / PT-7)
+
+> **Status: SCAFFOLD — `pending-key`.** Everything is wired except the API key.
+> Drop in `INFRANODUS_API_KEY` and the gap-analysis skill goes live. No live
+> connection is fabricated here.
+
+InfraNodus is the **topology lens** for the Centaurion wiki: it turns wiki text
+into a knowledge graph and surfaces *structural holes* — disconnected topical
+clusters and the bridge concepts that would connect them. This is the engine
+behind `skills/gap-analysis/` ("What are we NOT seeing?").
+
+---
+
+## 1. Sign up & get an API key
+
+1. Go to **https://infranodus.com** and create an account (a trial tier is enough
+   to validate the integration).
+2. Open **https://infranodus.com/api-access** and copy your API token.
+
+## 2. Set the key on the host
+
+The key lives in the host `.env` (gitignored, `600` perms) — never in the repo.
+
+```bash
+# On the host (e.g. Hermes / VPS1), append to /root/Centaurion/.env :
+echo 'INFRANODUS_API_KEY=in_xxxxxxxxxxxxxxxxxxxx' >> /root/Centaurion/.env
+chmod 600 /root/Centaurion/.env
+```
+
+Confirm it loads:
+
+```bash
+set -a; . /root/Centaurion/.env; set +a
+test -n "$INFRANODUS_API_KEY" && echo "INFRANODUS_API_KEY is set" || echo "MISSING"
+```
+
+## 3. Wire the MCP server (preferred path)
+
+The official server is `infranodus-mcp-server` (npx). Merge the `mcpServers`
+entry from [`mcp.json`](./mcp.json) into the host's Claude Code MCP config
+(`~/.claude.json`, or a project `.mcp.json`). With the env var exported, the
+server authenticates automatically. Relevant tools for gap analysis:
+
+| Tool | Use |
+|------|-----|
+| `generate_knowledge_graph` | Build the graph from wiki text |
+| `generate_content_gaps`    | List structural holes (the gaps) |
+| `generate_topical_clusters`| Name the main clusters |
+| `generate_research_questions` | Turn gaps into research questions |
+| `develop_conceptual_bridges`  | Suggest bridge concepts |
+| `analyze_text`             | One-shot topology + summary |
+
+Quick check after wiring:
+
+```bash
+claude mcp list   # 'infranodus' should appear and connect
+```
+
+## 4. HTTP API (equivalent path, no MCP)
+
+If you'd rather not run the MCP server, the same capability is a REST call.
+Base URL `https://infranodus.com/api/v1/`, bearer auth.
+
+```bash
+set -a; . /root/Centaurion/.env; set +a
+
+# Topology + gaps for a wiki page (gapDepth 0 = most prominent gaps):
+curl -s https://infranodus.com/api/v1/dotGraphFromText \
+  -H "Authorization: Bearer $INFRANODUS_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "$(jq -n --arg text "$(cat docs/centaurion-wiki/*.md)" \
+        '{name:"centaurion-wiki", text:$text, gapDepth:0, includeStatements:false}')" \
+  | jq '{summary: .graphSummary, gaps: .attributes.gaps}'
+```
+
+- `graphSummary` — natural-language topology summary.
+- `attributes.gaps` — the structural holes (each = a bridge-question candidate).
+- `gapDepth` (0–3) — raise it to iterate from obvious gaps to subtler ones.
+
+## 5. Run a gap analysis over the wiki
+
+Once the key is set, invoke the skill:
+
+```
+/gap-analysis            # or: "run the gap analysis" / "what are we missing?"
+```
+
+The skill loads the wiki sources (`docs/centaurion-wiki`, and the `aob-wiki` /
+`builderbee-wiki` repos once they're split out — see PT-7), runs them through
+InfraNodus (MCP tools or the HTTP calls above), and emits the weekly format from
+`skills/gap-analysis/SKILL.md`: coverage table, gaps, cross-wiki bridges, and
+generated research questions. Highest-value gaps are usually *between* wikis.
+
+---
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `memory/infranodus.json` | Integration descriptor (status, endpoints, MCP, consumers) |
+| `deploy/infranodus/mcp.json` | MCP server config snippet to merge into the host MCP config |
+| `deploy/infranodus/README.md` | This runbook |
+| `skills/gap-analysis/SKILL.md` | The consumer skill (see its **InfraNodus Integration** section) |
+
+## Operator step (the one thing left)
+
+**Add `INFRANODUS_API_KEY` to `/root/Centaurion/.env` on the host.** That single
+step flips the integration from `scaffolded` to live. Everything else is done.

--- a/deploy/infranodus/mcp.json
+++ b/deploy/infranodus/mcp.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "InfraNodus MCP server for gap analysis (Phase 9 / PT-7). SCAFFOLD — needs INFRANODUS_API_KEY to activate. Merge this `mcpServers` entry into the host's Claude Code MCP config (e.g. ~/.claude.json or project .mcp.json). The key is read from the host environment, NOT hardcoded here. See deploy/infranodus/README.md.",
+  "mcpServers": {
+    "infranodus": {
+      "command": "npx",
+      "args": ["-y", "infranodus-mcp-server"],
+      "env": {
+        "INFRANODUS_API_KEY": "${INFRANODUS_API_KEY}"
+      }
+    }
+  }
+}

--- a/memory/infranodus.json
+++ b/memory/infranodus.json
@@ -1,0 +1,52 @@
+{
+  "service": "infranodus",
+  "description": "Layer 2b: Topology lens — knowledge-gap detection over the wiki repos via text-network analysis (clusters, structural holes, bridge concepts, research questions)",
+  "status": "scaffolded",
+  "activation": "pending-key",
+  "tier": "trial",
+  "apiKey": "${INFRANODUS_API_KEY}",
+  "apiKeySource": "env:INFRANODUS_API_KEY",
+  "apiKeyPath": "/root/Centaurion/.env (gitignored, 600 perms)",
+  "signup": "https://infranodus.com/api-access",
+  "auth": {
+    "scheme": "bearer",
+    "header": "Authorization: Bearer ${INFRANODUS_API_KEY}"
+  },
+  "endpoints": {
+    "baseUrl": "https://infranodus.com/api/v1/",
+    "graphAndStatements": "POST https://infranodus.com/api/v1/graphAndStatements",
+    "dotGraphFromText": "POST https://infranodus.com/api/v1/dotGraphFromText"
+  },
+  "responseShape": {
+    "gaps": "attributes.gaps — structural holes between topical clusters (candidate content / bridge questions)",
+    "graphSummary": "string — compact natural-language summary of the topology",
+    "extendedGraphSummary": "object — topical-cluster insights"
+  },
+  "params": {
+    "gapDepth": "0-3; 0 = most prominent gaps, 1-3 = progressively deeper/subtler structural holes"
+  },
+  "mcp": {
+    "package": "infranodus-mcp-server",
+    "configFile": "deploy/infranodus/mcp.json",
+    "envVar": "INFRANODUS_API_KEY",
+    "tools": [
+      "generate_knowledge_graph",
+      "generate_content_gaps",
+      "generate_topical_clusters",
+      "generate_research_questions",
+      "develop_conceptual_bridges",
+      "analyze_text"
+    ],
+    "notes": "Official MCP server. 30 tools total; the listed subset is what gap-analysis consumes. HTTP API (endpoints above) is the equivalent integration if MCP is not wired."
+  },
+  "consumers": {
+    "skill": "skills/gap-analysis/SKILL.md",
+    "targets": [
+      "docs/centaurion-wiki",
+      "MalikJPalamar/aob-wiki",
+      "MalikJPalamar/builderbee-wiki"
+    ]
+  },
+  "verifiedRoundTrip": false,
+  "notes": "Purpose: 'What are we NOT seeing?' Detects disconnected knowledge clusters and the bridge concepts that would connect them. SCAFFOLD ONLY — no live key present. Set INFRANODUS_API_KEY in the host .env to activate; see deploy/infranodus/README.md. Mirrors the documented-integration pattern of memory/supermemory.json."
+}

--- a/skills/gap-analysis/SKILL.md
+++ b/skills/gap-analysis/SKILL.md
@@ -11,7 +11,7 @@ Analyze the three LLM Wiki repos (aob-wiki, builderbee-wiki, centaurion-wiki) fo
 
 ## Prerequisites
 
-- InfraNodus MCP server connected (or InfraNodus skill installed)
+- InfraNodus connected — MCP server **or** HTTP API (see **InfraNodus Integration** below). Needs `INFRANODUS_API_KEY` on the host; until then the integration is `scaffolded`/`pending-key` and you fall back to manual topology reasoning.
 - At least one wiki repo with content to analyze
 - Wiki repos: `MalikJPalamar/aob-wiki`, `MalikJPalamar/builderbee-wiki`, `MalikJPalamar/centaurion-wiki`
 
@@ -68,6 +68,35 @@ For each identified gap, generate a research question:
 ## Recommended Actions
 - [Specific wiki pages to create or update]
 ```
+
+## InfraNodus Integration
+
+InfraNodus is the engine for steps 2–4 above. It builds a text-network graph of
+the wiki and returns the *structural holes* (gaps) plus the bridge concepts and
+research questions that fill them. **Status: scaffolded — set `INFRANODUS_API_KEY`
+on the host to activate.** Full runbook: `deploy/infranodus/README.md`. Descriptor:
+`memory/infranodus.json`.
+
+**Two equivalent paths:**
+
+1. **MCP (preferred)** — config snippet in `deploy/infranodus/mcp.json`
+   (`infranodus-mcp-server` via npx). Once the key is set and the server is merged
+   into the host MCP config, call these tools on the wiki text:
+   - `generate_knowledge_graph` → build the graph
+   - `generate_topical_clusters` → name the clusters (step 2)
+   - `generate_content_gaps` → list structural holes (step 2)
+   - `develop_conceptual_bridges` → bridge concepts (step 2)
+   - `generate_research_questions` → turn gaps into questions (step 4)
+
+2. **HTTP API** — `POST https://infranodus.com/api/v1/dotGraphFromText` with
+   `Authorization: Bearer ${INFRANODUS_API_KEY}`, body `{name, text, gapDepth}`.
+   Read `.graphSummary` and `.attributes.gaps` from the response. `gapDepth` 0→3
+   walks from the most prominent gaps to subtler ones (re-run, raising it, to mine
+   the cross-wiki gaps in step 3). See the README for a copy-paste `curl`.
+
+**Invocation:** with the key set, run `/gap-analysis` (or "what are we missing?").
+Without the key, proceed with manual topology reasoning and flag that InfraNodus
+is `pending-key` in the output.
 
 ## Example
 


### PR DESCRIPTION
## What

Wires **InfraNodus** knowledge-gap analysis against the wiki content as an honest **scaffold** — everything in place except the API key. **No live connection or key is fabricated.** Status: `scaffolded` / `pending-key`.

Builds on the existing `skills/gap-analysis/` skill (integrates, does not duplicate) and mirrors the documented-integration style of `memory/supermemory.json`.

## Changes (only these 4 paths)

- **`memory/infranodus.json`** — integration descriptor: status, bearer auth, HTTP endpoints (`/api/v1/dotGraphFromText`, `/graphAndStatements`), `gapDepth`, MCP package + tools, consumers. Key is an env-ref `${INFRANODUS_API_KEY}`.
- **`deploy/infranodus/mcp.json`** — MCP server config snippet for `infranodus-mcp-server` (npx); key read from host env, not hardcoded.
- **`deploy/infranodus/README.md`** — runbook: sign up at infranodus.com → get key → set `INFRANODUS_API_KEY` in host `.env` → wire MCP (or HTTP API) → run gap analysis over `docs/*-wiki`.
- **`skills/gap-analysis/SKILL.md`** — new **InfraNodus Integration** section (MCP tools + HTTP path, invocation) and updated prereq.
- **`.planning/ROADMAP.md`** — PT-7 note (scaffold added; needs key); **left unchecked**.

## API shape (researched, infranodus.com)

Base `https://infranodus.com/api/v1/`, `Authorization: Bearer ${INFRANODUS_API_KEY}`. `POST text → graphSummary + attributes.gaps`. Official MCP server `infranodus-mcp-server` is the preferred path; HTTP API documented as the equivalent.

## Operator step (the one thing left)

**Add `INFRANODUS_API_KEY` to `/root/Centaurion/.env` on the host.** That flips it from `scaffolded` to live. Everything else is done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)