### PR TITLE
feat(dashboard): PT-5 retire remaining mock endpoints (ai-operations, pipelines, settings)

### DIFF
--- a/backend/api/live_data.py
+++ b/backend/api/live_data.py
@@ -186,3 +186,129 @@ def get_live_status() -> dict:
         "ratings_count": len(ratings),
         "generated_at": datetime.now(timezone.utc).isoformat(),
     }
+
+
+def _route_status(r: dict) -> str:
+    """Map a routing entry to an operation status using its recorded outcome."""
+    if r.get("routing_correct") is False:
+        return "failed"
+    if isinstance(r.get("outcome_rating"), (int, float)):
+        return "completed"
+    return "logged"
+
+
+def get_ai_operations() -> dict:
+    """Real 'operations' derived from logged routing decisions + the live dev loop.
+
+    Each routing decision becomes one operation; the current dev-loop run (if active)
+    is surfaced as an in-progress operation at the top. Shape matches the old mock:
+    a list of {id, name, type, status, created_at} under "operations" with "total".
+    """
+    routing = _routing_entries()
+    operations = []
+
+    devloop = _read_json("memory/state/dev-loop-status.json")
+    dl_status = str(devloop.get("status", "")).lower()
+    if dl_status:
+        running = dl_status in {"progressing", "running", "in_progress", "active"}
+        operations.append(
+            {
+                "id": f"devloop-{devloop.get('date', 'current')}",
+                "name": f"Dev loop — phase {devloop.get('phase', '?')}, "
+                f"{devloop.get('tests_remaining', '?')} checks remaining",
+                "type": "dev_loop",
+                "status": "running" if running else dl_status,
+                "created_at": devloop.get("timestamp"),
+            }
+        )
+
+    for i, r in enumerate(
+        sorted(routing, key=lambda x: x.get("timestamp", ""), reverse=True)
+    ):
+        task = (r.get("task") or "Routing decision")[:80]
+        operations.append(
+            {
+                "id": f"route-{i:04d}",
+                "name": task,
+                "type": str(r.get("route", "route")),
+                "status": _route_status(r),
+                "created_at": r.get("timestamp"),
+            }
+        )
+
+    return {"operations": operations, "total": len(operations)}
+
+
+def _workflow_name(path: str) -> str:
+    """Extract a workflow's `name:` field; fall back to the filename."""
+    try:
+        with open(path, encoding="utf-8") as fh:
+            for line in fh:
+                stripped = line.strip()
+                if stripped.startswith("name:"):
+                    name = stripped[len("name:"):].strip().strip("'\"")
+                    if name:
+                        return name
+    except OSError:
+        pass
+    return os.path.basename(path)
+
+
+def get_pipelines() -> dict:
+    """Real CI/CD pipelines read from .github/workflows/*.yml|*.yaml.
+
+    Status is "configured": runtime querying of the Actions API needs a token we
+    deliberately do not embed. Shape matches the old mock: {id, name, status, branch}.
+    """
+    paths = sorted(
+        glob.glob(_path(".github/workflows/*.yml"))
+        + glob.glob(_path(".github/workflows/*.yaml"))
+    )
+    pipelines = []
+    for path in paths:
+        stem = os.path.splitext(os.path.basename(path))[0]
+        pipelines.append(
+            {
+                "id": f"pipe-{stem}",
+                "name": _workflow_name(path),
+                "status": "configured",
+                "branch": "main",
+            }
+        )
+    return {"pipelines": pipelines, "total": len(pipelines)}
+
+
+def get_settings() -> dict:
+    """Real configuration summary — repo identity + memory service status.
+
+    Reads memory/supermemory.json for the memory bus config. Never surfaces raw
+    secret values: the apiKey there is an env-ref placeholder, and we report only
+    whether the backing env var is set, never the value itself.
+    """
+    supermem = _read_json("memory/supermemory.json")
+    api_key_ref = str(supermem.get("apiKey", ""))
+    # Only report configured-ness, never the raw value. The committed value is an
+    # env-ref placeholder ("${SUPERMEMORY_API_KEY}"); resolve presence from the env.
+    env_var = str(supermem.get("apiKeySource", "")).split(":", 1)[-1] or "SUPERMEMORY_API_KEY"
+    key_configured = bool(os.environ.get(env_var)) or api_key_ref.startswith("${")
+
+    return {
+        "identity": {
+            "service": "Centaurion",
+            "description": "AI-Driven Cognitive Operating System",
+            "version": "1.0.0",
+        },
+        "memory": {
+            "service": supermem.get("service", "supermemory"),
+            "tier": supermem.get("tier", "unknown"),
+            "status": supermem.get("status", "unknown"),
+            "api_key_configured": key_configured,
+            "auto_capture": bool(supermem.get("autoCapture", False)),
+            "auto_recall": bool(supermem.get("autoRecall", False)),
+        },
+        "preferences": {
+            "theme": "dark",
+            "auto_refresh": True,
+            "refresh_interval": 30,
+        },
+    }

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -1,13 +1,10 @@
 from fastapi import APIRouter
 from api.mock_data import (
-    get_ai_operations,
     create_ai_operation,
     get_operation_by_id,
     get_market_intelligence,
     generate_report,
-    get_pipelines,
     trigger_pipeline,
-    get_settings,
     update_settings
 )
 # Real Centaurion state (reads committed routing-log/ratings/dev-loop/workflows).
@@ -15,6 +12,9 @@ from api.live_data import (
     get_dashboard_stats,
     get_health_status,
     get_live_status,
+    get_ai_operations,
+    get_pipelines,
+    get_settings,
 )
 
 router = APIRouter()

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -73,3 +73,60 @@ def test_cicd_health_is_live():
     assert "services" in data and isinstance(data["services"], list)
     names = {s["name"] for s in data["services"]}
     assert "Dev Loop" in names  # proves it's the live provider, not mock
+
+
+# The old mock fixture ids — their absence proves we serve real data now.
+_MOCK_OP_IDS = {"op-001", "op-002", "op-003", "op-004", "op-005"}
+_MOCK_PIPE_IDS = {"pipe-001", "pipe-002", "pipe-003", "pipe-004"}
+
+
+def test_ai_operations_are_live_not_mock():
+    resp = client.get("/api/ai-operations")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "operations" in data and isinstance(data["operations"], list)
+    assert data["total"] == len(data["operations"])
+    assert data["operations"], "live ops derive from routing log + dev loop"
+    for op in data["operations"]:
+        for key in ("id", "name", "type", "status", "created_at"):
+            assert key in op, f"operation missing {key}"
+    ids = {op["id"] for op in data["operations"]}
+    assert ids.isdisjoint(_MOCK_OP_IDS), "must not return old mock operation ids"
+    # The dev-loop run is surfaced as a real operation.
+    assert any(op["type"] == "dev_loop" for op in data["operations"])
+
+
+def test_cicd_pipelines_are_live_not_mock():
+    resp = client.get("/api/cicd/pipelines")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "pipelines" in data and isinstance(data["pipelines"], list)
+    assert data["total"] == len(data["pipelines"])
+    assert data["pipelines"], "live pipelines come from .github/workflows/*"
+    for p in data["pipelines"]:
+        for key in ("id", "name", "status", "branch"):
+            assert key in p, f"pipeline missing {key}"
+        assert p["branch"] == "main"
+        assert p["status"] == "configured"
+    ids = {p["id"] for p in data["pipelines"]}
+    assert ids.isdisjoint(_MOCK_PIPE_IDS), "must not return old mock pipeline ids"
+
+
+def test_settings_are_live_not_mock():
+    import json
+
+    resp = client.get("/api/settings")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, dict)
+    # Real config shape: identity + memory, not the old api_keys/notifications mock.
+    assert "identity" in data and "memory" in data
+    assert "api_keys" not in data, "must not return old mock settings shape"
+    assert data["identity"]["service"] == "Centaurion"
+    assert data["identity"]["version"] == "1.0.0"
+    assert data["memory"]["service"] == "supermemory"
+    # Never surface a raw secret value — only a boolean configured flag.
+    assert isinstance(data["memory"]["api_key_configured"], bool)
+    serialized = json.dumps(data)
+    assert "${" not in serialized, "no env-ref placeholders leaked"
+    assert "SUPERMEMORY_API_KEY" not in serialized


### PR DESCRIPTION
## PT-5 — retire remaining MOCK endpoints

Serves REAL data from the last three mock endpoints, matching the defensive `backend/api/live_data.py` pattern (same `_path`/`_read_jsonl`/`_read_json` helpers, never 500 on missing files).

### What each endpoint now returns
- **`GET /api/ai-operations`** — operations derived from `memory/state/routing-log.jsonl` decisions (`id`, `name`=task truncated, `type`=route, `status`, `created_at`=timestamp), with the active dev-loop run surfaced as a running operation at the top. Shape kept compatible (`{operations: [...], total}`).
- **`GET /api/cicd/pipelines`** — reads `.github/workflows/*.yml|*.yaml`; each pipeline is `{id, name (from the workflow `name:` field), status:"configured", branch:"main"}`. No Actions token is embedded — runtime status querying is intentionally out of scope.
- **`GET /api/settings`** — real config: repo identity (`service`, `version` "1.0.0") plus a `memory` summary from `memory/supermemory.json` (`service`, `tier`, `status`). Reports only an `api_key_configured` boolean — never a raw secret or the `${SUPERMEMORY_API_KEY}` env-ref.

`routes.py` now imports these three from `live_data`; `get_market_intelligence` / `generate_report` stay on mock (out of scope). Mutation helpers (`create_ai_operation`, `trigger_pipeline`, `update_settings`) remain on mock.

### Tests
Extended `tests/test_backend_api.py` with assertions that all three endpoints return real-shaped data with the expected keys and that the old mock fixture ids (`op-00x`, `pipe-00x`) and mock settings shape (`api_keys`) are gone. Settings test also asserts no secret/env-ref leaks.

```
8 passed, 1 warning in 0.38s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)