### PR TITLE
feat(phase-9): PT-7 Syncthing scaffold for VPS1<->VPS2 wiki sync

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -100,6 +100,9 @@
 ### P3 — Phase 9 infra remainder
 - [ ] **PT-7** Syncthing (VPS1↔VPS2 wiki sync), InfraNodus MCP (gap analysis),
   wikis-as-separate-repos. **Done when:** Phase 9 DoD infra items met.
+  - Syncthing scaffold added (`deploy/syncthing/`) — activation needs a run on
+    each host (install + device-ID exchange + folder share on VPS1 *and* VPS2).
+    Checkbox stays unchecked until both hosts are paired and "Up to Date".
 
 **Sequencing:** PT-1 (clean footing) → PT-2/3/4 (system is real & live) → PT-5/6 (polish & reliability) → PT-7 (infra).
 

--- a/deploy/syncthing/README.md
+++ b/deploy/syncthing/README.md
@@ -1,0 +1,215 @@
+# Syncthing — P2P Wiki Sync (PT-7a)
+
+Part of **Phase 9 / PT-7**. Keeps the Centaurion wikis under `docs/` in sync
+between the two hosts over a direct, encrypted peer-to-peer channel — no central
+server, no git round-trip, no cloud dependency.
+
+> **Status: SCAFFOLD, not yet active.** These files are a deployable runbook.
+> Activation is a two-host pairing handshake that *must* be run on **both**
+> machines (each generates its own device ID, then each adds the other). Nothing
+> here was executed on a live host — see [Manual steps](#manual-steps-operator).
+
+## Topology
+
+```
+┌─────────────────────────────┐         ┌─────────────────────────────┐
+│ VPS1                        │ <─────> │ VPS2 / container host       │
+│ 187.124.45.132              │  P2P    │ srv1514399                  │
+│                             │ (TLS,   │                             │
+│ ~/Centaurion/docs/          │ direct) │ ~/Centaurion/docs/          │
+│   centaurion-wiki/          │         │   centaurion-wiki/          │
+│   aob-wiki/                 │         │   aob-wiki/                 │
+│   builderbee-wiki/          │         │   builderbee-wiki/          │
+└─────────────────────────────┘         └─────────────────────────────┘
+         folder id: centaurion-wiki  (send-receive on both)
+```
+
+- **Synced folder:** the wiki content under `docs/` (see
+  [folder-config.md](folder-config.md) for the exact folder ID, path, and type).
+- **Transport:** Syncthing's own block-exchange protocol — mutual-TLS, device-ID
+  pinned. Goes direct when the hosts can reach each other; falls back to the
+  public relay pool otherwise. No inbound port is strictly required to *start*,
+  but opening **TCP/UDP 22000** on both ends makes sync direct and fast.
+- **Why P2P (not git):** wikis change from either host (dev-loop on VPS2, manual
+  edits on VPS1). Syncthing gives near-real-time bidirectional convergence with
+  automatic conflict files, without either host needing push access to the other.
+
+## Current state on this host (srv1514399)
+
+At scaffold time, `which syncthing` returned **not installed**. Run
+[`install.sh`](install.sh) to install it, then follow the runbook below.
+
+## What's in this directory
+
+| File               | Purpose                                                          |
+|--------------------|------------------------------------------------------------------|
+| `README.md`        | This file — topology + runbook.                                  |
+| `install.sh`       | Idempotent Syncthing install (apt repo + systemd) + prints ID.   |
+| `folder-config.md` | The shared-folder definition both hosts must configure identically. |
+| `verify.sh`        | Read-only status check (installed? running? prints device ID).   |
+
+---
+
+## RUNBOOK
+
+Do **all** of these on **both** hosts unless a step says otherwise. The pairing
+is symmetric: each host adds the *other* as a remote device, then one side shares
+the folder and the other accepts it.
+
+### Step 0 — Prerequisites (both hosts)
+
+```bash
+# Run as the user that owns ~/Centaurion (NOT root, unless that's the repo owner).
+whoami
+ls -d ~/Centaurion/docs   # confirm the wiki tree exists at the expected path
+```
+
+### Step 1 — Install Syncthing (both hosts)
+
+```bash
+cd ~/Centaurion
+bash deploy/syncthing/install.sh
+```
+
+The script installs from the official Syncthing apt repo, enables the per-user
+systemd service (`syncthing@<user>`), starts it, and prints this host's
+**device ID** at the end. Copy that ID — you need it on the *other* host.
+
+> The Web GUI binds to `127.0.0.1:8384` by default (local only). To reach it
+> from your laptop over SSH: `ssh -L 8384:127.0.0.1:8384 user@<host>` then open
+> <http://127.0.0.1:8384>. All steps below can also be done from the GUI; the
+> CLI/`curl` commands are given so the whole thing is scriptable from a phone.
+
+### Step 2 — Get each device ID
+
+On each host:
+
+```bash
+syncthing --device-id
+# or, if it's already running:
+bash deploy/syncthing/verify.sh
+```
+
+Record them:
+
+- `DEVICE_ID_VPS1` = (from 187.124.45.132)
+- `DEVICE_ID_VPS2` = (from srv1514399)
+
+### Step 3 — Add the remote device (on BOTH hosts)
+
+Easiest path is the Web GUI: **Add Remote Device** → paste the *other* host's ID
+→ name it (`vps1` or `vps2`) → for the address use `tcp://<other-host-ip>:22000`
+or leave `dynamic` to let the relay/discovery find it.
+
+- On **VPS1**, add `DEVICE_ID_VPS2`, address `tcp://srv1514399:22000` (or
+  `dynamic`).
+- On **VPS2 (srv1514399)**, add `DEVICE_ID_VPS1`, address
+  `tcp://187.124.45.132:22000` (or `dynamic`).
+
+CLI/API equivalent (uses the local API key from `config.xml`; run on each host,
+substituting the *other* host's ID and IP):
+
+```bash
+API_KEY=$(syncthing cli config gui apikey get 2>/dev/null || \
+          sed -n 's:.*<apikey>\(.*\)</apikey>.*:\1:p' ~/.local/state/syncthing/config.xml 2>/dev/null || \
+          sed -n 's:.*<apikey>\(.*\)</apikey>.*:\1:p' ~/.config/syncthing/config.xml)
+
+syncthing cli --gui-apikey "$API_KEY" config devices add \
+  --device-id "<OTHER_DEVICE_ID>" || true
+# then set a friendly name + address via the GUI, or:
+syncthing cli --gui-apikey "$API_KEY" config devices "<OTHER_DEVICE_ID>" \
+  addresses set "tcp://<OTHER_HOST_IP>:22000"
+```
+
+Each side will show the other as "Disconnected (unused)" until the folder is
+shared — that's expected.
+
+### Step 4 — Define the shared folder (on the FIRST host, e.g. VPS1)
+
+Use the exact values from [folder-config.md](folder-config.md):
+
+- **Folder ID:** `centaurion-wiki`  *(must be identical on both hosts)*
+- **Folder Path:** `~/Centaurion/docs`  *(absolute path on each host)*
+- **Folder Type:** `Send & Receive`
+- **Share with:** the remote device you added in Step 3.
+
+GUI: **Add Folder** → set ID + path → **Sharing** tab → tick the remote device →
+**Advanced** → File Versioning = *Simple* (keep 5) so a bad sync is recoverable.
+
+CLI/API equivalent:
+
+```bash
+syncthing cli --gui-apikey "$API_KEY" config folders add \
+  --id centaurion-wiki --label "Centaurion Wiki" --path "$HOME/Centaurion/docs"
+syncthing cli --gui-apikey "$API_KEY" config folders centaurion-wiki \
+  devices add --device-id "<OTHER_DEVICE_ID>"
+```
+
+### Step 5 — Accept the folder (on the SECOND host, e.g. VPS2)
+
+When the first host shares the folder, the second host gets a notification:
+**"<host> wants to share folder centaurion-wiki"** → **Add** → set the path to
+`~/Centaurion/docs` (the same place on this host) → Folder Type
+**Send & Receive** → Save.
+
+If you don't see the prompt (relay lag), add the folder manually with the **same
+folder ID** `centaurion-wiki` and share it back with the first device — Syncthing
+matches folders by ID across devices.
+
+### Step 6 — Set send/receive mode (both hosts)
+
+Confirm the folder type is **Send & Receive** on *both* hosts so edits flow both
+ways. (Use *Receive Only* on a host only if you want it to be a read replica —
+not the default for this setup.)
+
+### Step 7 — Verify sync
+
+```bash
+bash deploy/syncthing/verify.sh        # run on each host
+```
+
+Then confirm convergence end-to-end:
+
+```bash
+# On VPS1:
+echo "sync probe $(date -u +%FT%TZ)" >> ~/Centaurion/docs/.synctest
+# Within a few seconds, on VPS2:
+cat ~/Centaurion/docs/.synctest        # should show the same line
+# Clean up afterwards (on either host — deletion also syncs):
+rm ~/Centaurion/docs/.synctest
+```
+
+In the GUI both devices should read **"Up to Date"** and the remote device should
+show **Connected**. PT-7a is "done" only once this round-trip succeeds on both
+hosts.
+
+---
+
+## Operational notes
+
+- **`.stignore`:** Syncthing reads a `.stignore` file at the folder root to skip
+  paths. If you do **not** want `docs/`'s own scratch files or VCS metadata
+  synced, add a `.stignore` inside `~/Centaurion/docs/` on both hosts. See
+  `folder-config.md`.
+- **Conflicts:** simultaneous edits to the same file on both hosts produce a
+  `*.sync-conflict-*.md` file rather than silent data loss. Resolve by hand and
+  delete the loser.
+- **Firewall:** if sync stays stuck on relays and feels slow, open `22000/tcp`
+  and `22000/udp` (and `21027/udp` for LAN discovery, irrelevant across the WAN)
+  on both hosts and re-add the device address as `tcp://<ip>:22000`.
+- **Service control:** `systemctl --user status syncthing@$USER`,
+  `journalctl --user -u syncthing@$USER -f`.
+
+## Manual steps (operator)
+
+These **cannot** be done from this container and must be run on the hosts:
+
+1. Run `install.sh` on **VPS1 (187.124.45.132)** — it is not installed there yet
+   (only this container, srv1514399, was inspected).
+2. Run `install.sh` on **VPS2 (srv1514399)** — `which syncthing` was empty at
+   scaffold time.
+3. Exchange the two device IDs (Step 2) and add each as a remote device on the
+   other host (Step 3) — a mutual handshake; one host alone can't complete it.
+4. Share + accept the `centaurion-wiki` folder (Steps 4–6) on both hosts.
+5. Run the Step 7 round-trip probe and confirm "Up to Date" on both. Only then
+   check the **PT-7** box in `.planning/ROADMAP.md`.

--- a/deploy/syncthing/folder-config.md
+++ b/deploy/syncthing/folder-config.md
@@ -1,0 +1,95 @@
+# Syncthing Shared-Folder Config — `centaurion-wiki`
+
+Both hosts must configure the synced folder **identically by ID**. Syncthing
+matches folders across devices by their folder ID, so the ID below must be exactly
+the same on VPS1 and VPS2. The on-disk path may differ per host but is the same
+here because both clone the repo to `~/Centaurion`.
+
+## Canonical definition
+
+| Setting          | Value                                  | Notes                                            |
+|------------------|----------------------------------------|--------------------------------------------------|
+| **Folder ID**    | `centaurion-wiki`                      | Identical on both hosts. Do not change.          |
+| **Folder Label** | `Centaurion Wiki`                      | Cosmetic; can differ per host.                   |
+| **Folder Path**  | `~/Centaurion/docs`                    | Absolute path on each host. Same relative spot.  |
+| **Folder Type**  | `Send & Receive`                       | Bidirectional on both hosts.                     |
+| **Shared with**  | the other host's device               | VPS1 ↔ VPS2.                                      |
+| **Rescan**       | `3600` s (default) or use watcher      | `fsWatcherEnabled=true` for near-real-time.      |
+| **Versioning**   | `Simple`, keep `5`                     | Lets you recover from a bad sync / accidental rm.|
+| **Ignore Perms** | off (default)                          | Both are Linux; keep perms in sync.              |
+
+> **Why `docs/` and not just `docs/centaurion-wiki/`?** PT-7 calls for the wiki
+> content under `docs/`, which holds `centaurion-wiki/`, `aob-wiki/`, and
+> `builderbee-wiki/` plus top-level wiki docs. One folder rooted at `docs/` syncs
+> all three wikis in a single share. If you want to sync *only* one wiki, set the
+> path to that subdirectory and pick a distinct folder ID (e.g. `aob-wiki`).
+
+## Equivalent `config.xml` fragment
+
+This is what the folder stanza looks like inside Syncthing's `config.xml`
+(`~/.local/state/syncthing/config.xml` on recent builds, or
+`~/.config/syncthing/config.xml` on older ones). Replace the device IDs with the
+real ones from `install.sh`; do **not** hand-edit `config.xml` while the daemon is
+running — prefer the GUI or `syncthing cli config`.
+
+```xml
+<folder id="centaurion-wiki" label="Centaurion Wiki"
+        path="/home/USER/Centaurion/docs"
+        type="sendreceive" rescanIntervalS="3600"
+        fsWatcherEnabled="true" fsWatcherDelayS="10"
+        ignorePerms="false">
+  <!-- This host -->
+  <device id="THIS_HOST_DEVICE_ID"></device>
+  <!-- The remote host (VPS1 or VPS2) -->
+  <device id="OTHER_HOST_DEVICE_ID"></device>
+  <versioning type="simple">
+    <param key="keep" val="5"></param>
+  </versioning>
+</folder>
+```
+
+And the matching remote-device stanza (one per host, pointing at the *other*):
+
+```xml
+<device id="OTHER_HOST_DEVICE_ID" name="vps1-or-vps2" compression="metadata">
+  <!-- Optional explicit address; 'dynamic' lets discovery/relays find it -->
+  <address>tcp://OTHER_HOST_IP:22000</address>
+  <address>dynamic</address>
+</device>
+```
+
+## Scriptable (CLI) equivalent
+
+Run on each host after both device IDs are known (see README Step 3-4):
+
+```bash
+API_KEY=$(syncthing cli config gui apikey get)
+
+# Define the folder
+syncthing cli --gui-apikey "$API_KEY" config folders add \
+  --id centaurion-wiki --label "Centaurion Wiki" --path "$HOME/Centaurion/docs"
+syncthing cli --gui-apikey "$API_KEY" config folders centaurion-wiki \
+  type set sendreceive
+
+# Share it with the remote device
+syncthing cli --gui-apikey "$API_KEY" config folders centaurion-wiki \
+  devices add --device-id "<OTHER_DEVICE_ID>"
+```
+
+## Optional `.stignore`
+
+To keep VCS metadata and scratch files out of the sync, drop this file at the
+folder root (`~/Centaurion/docs/.stignore`) on **both** hosts (identical content):
+
+```gitignore
+// Syncthing ignore patterns for the centaurion-wiki folder
+.git
+.DS_Store
+*.tmp
+*.swp
+.synctest
+// Keep conflict files visible so you notice them:
+!*.sync-conflict-*
+```
+
+`.stignore` itself is **not** synced and must be created on each host.

--- a/deploy/syncthing/install.sh
+++ b/deploy/syncthing/install.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# ═══════════════════════════════════════════════════════════
+# Centaurion — Syncthing Install (PT-7a)
+# ═══════════════════════════════════════════════════════════
+#
+# Idempotent install of Syncthing on a Debian/Ubuntu host.
+# Installs from the official Syncthing apt repo, enables the
+# per-user systemd service, starts it, and prints this host's
+# device ID + the next step.
+#
+# Run on EACH host (VPS1 187.124.45.132 and VPS2 srv1514399).
+# Run as the user that owns ~/Centaurion (a real login user with
+# a home dir, not a system account) — the per-user service syncs
+# that user's files.
+#
+# Usage:
+#   cd ~/Centaurion && bash deploy/syncthing/install.sh
+#
+# Safe to re-run: every step is guarded.
+# ═══════════════════════════════════════════════════════════
+
+set -uo pipefail
+
+KEYRING="/usr/share/keyrings/syncthing-archive-keyring.gpg"
+LIST="/etc/apt/sources.list.d/syncthing.list"
+SVC_USER="${SUDO_USER:-$USER}"
+
+say()  { echo "▸ $*"; }
+ok()   { echo "  ✓ $*"; }
+warn() { echo "  ⚠ $*"; }
+
+# sudo wrapper — works whether or not we're already root
+SUDO=""
+if [ "$(id -u)" -ne 0 ]; then
+  if command -v sudo >/dev/null 2>&1; then
+    SUDO="sudo"
+  else
+    echo "✗ Need root (or sudo) to install packages. Re-run as root or install sudo." >&2
+    exit 1
+  fi
+fi
+
+echo "═══ Syncthing Install — $(hostname) ═══"
+echo "Service user: $SVC_USER"
+echo ""
+
+# ── Step 1: apt repo + key (idempotent) ─────────────────────
+say "Step 1: Syncthing apt repository"
+if command -v syncthing >/dev/null 2>&1; then
+  ok "syncthing already installed ($(syncthing --version 2>/dev/null | head -1)) — skipping repo + install"
+else
+  if [ ! -f "$KEYRING" ]; then
+    $SUDO mkdir -p "$(dirname "$KEYRING")"
+    if curl -fsSL https://syncthing.net/release-key.gpg | $SUDO tee "$KEYRING" >/dev/null; then
+      ok "Release key installed → $KEYRING"
+    else
+      echo "  ✗ Failed to fetch Syncthing release key (no network?)." >&2
+      exit 1
+    fi
+  else
+    ok "Release key already present"
+  fi
+
+  if [ ! -f "$LIST" ]; then
+    echo "deb [signed-by=$KEYRING] https://apt.syncthing.net/ syncthing stable" \
+      | $SUDO tee "$LIST" >/dev/null
+    ok "apt source added → $LIST"
+  else
+    ok "apt source already present"
+  fi
+
+  # ── Step 2: install package ──────────────────────────────
+  say "Step 2: apt-get install syncthing"
+  $SUDO apt-get update -qq
+  if $SUDO apt-get install -y -qq syncthing; then
+    ok "Installed $(syncthing --version 2>/dev/null | head -1)"
+  else
+    echo "  ✗ apt-get install syncthing failed." >&2
+    exit 1
+  fi
+fi
+
+# ── Step 3: generate config (so a device ID exists) ─────────
+say "Step 3: Initialise config / device identity"
+# `syncthing generate` creates the config + TLS keys for $SVC_USER if absent.
+# It is a no-op if the config already exists.
+if [ "$SVC_USER" != "$USER" ] && command -v runuser >/dev/null 2>&1; then
+  $SUDO runuser -u "$SVC_USER" -- syncthing generate >/dev/null 2>&1 || true
+else
+  syncthing generate >/dev/null 2>&1 || true
+fi
+ok "Config initialised (existing config left untouched)"
+
+# ── Step 4: enable + start per-user systemd service ─────────
+say "Step 4: Enable systemd user service (syncthing@$SVC_USER)"
+if command -v systemctl >/dev/null 2>&1 && [ -d /run/systemd/system ]; then
+  # Allow the user service to run without an active login session.
+  $SUDO loginctl enable-linger "$SVC_USER" 2>/dev/null \
+    && ok "Lingering enabled for $SVC_USER" \
+    || warn "Could not enable lingering (service may stop on logout)"
+
+  if $SUDO systemctl enable --now "syncthing@${SVC_USER}.service" 2>/dev/null; then
+    ok "Service enabled + started"
+  else
+    warn "systemctl enable --now failed — start manually with:"
+    echo "      systemctl enable --now syncthing@${SVC_USER}.service"
+  fi
+
+  # Give the daemon a moment to come up before we query it.
+  for _ in 1 2 3 4 5; do
+    systemctl is-active --quiet "syncthing@${SVC_USER}.service" && break
+    sleep 1
+  done
+else
+  warn "systemd not available (container without systemd?)."
+  echo "      Run Syncthing manually:  syncthing serve --no-browser &"
+fi
+
+# ── Step 5: print device ID + next step ─────────────────────
+echo ""
+say "Step 5: This host's device ID"
+DEVICE_ID=""
+if [ "$SVC_USER" != "$USER" ] && command -v runuser >/dev/null 2>&1; then
+  DEVICE_ID=$($SUDO runuser -u "$SVC_USER" -- syncthing --device-id 2>/dev/null)
+else
+  DEVICE_ID=$(syncthing --device-id 2>/dev/null)
+fi
+
+if [ -n "$DEVICE_ID" ]; then
+  echo ""
+  echo "    ┌──────────────────────────────────────────────────────────┐"
+  echo "    │ DEVICE ID ($(hostname)):"
+  echo "    │   $DEVICE_ID"
+  echo "    └──────────────────────────────────────────────────────────┘"
+else
+  warn "Could not read device ID yet. Once the service is up, run:"
+  echo "      syncthing --device-id"
+fi
+
+echo ""
+echo "═══ Done ═══"
+echo ""
+echo "NEXT STEPS (see deploy/syncthing/README.md → RUNBOOK):"
+echo "  1. Run this same script on the OTHER host."
+echo "  2. Copy each host's device ID above."
+echo "  3. On BOTH hosts: add the other device (README Step 3)."
+echo "  4. Share the 'centaurion-wiki' folder = ~/Centaurion/docs"
+echo "     as Send & Receive (README Steps 4-6; see folder-config.md)."
+echo "  5. Verify:  bash deploy/syncthing/verify.sh"
+echo ""
+echo "Web GUI (local only):  http://127.0.0.1:8384"
+echo "  Tunnel from laptop:  ssh -L 8384:127.0.0.1:8384 ${SVC_USER}@$(hostname)"

--- a/deploy/syncthing/verify.sh
+++ b/deploy/syncthing/verify.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# ═══════════════════════════════════════════════════════════
+# Centaurion — Syncthing Verify (PT-7a)
+# ═══════════════════════════════════════════════════════════
+#
+# Read-only status check. Reports whether Syncthing is installed
+# and running, prints this host's device ID, and (if reachable)
+# the configured folders + connected devices.
+#
+# Degrades gracefully: never installs, never mutates, never fails
+# the shell hard — exits 0 if healthy, 1 if absent/not running,
+# so it's safe to call from cron / health checks.
+#
+# Usage:
+#   bash deploy/syncthing/verify.sh
+# ═══════════════════════════════════════════════════════════
+
+set -uo pipefail
+
+SVC_USER="${SUDO_USER:-$USER}"
+RC=0
+
+echo "═══ Syncthing Verify — $(hostname) ═══"
+
+# ── Installed? ──────────────────────────────────────────────
+if command -v syncthing >/dev/null 2>&1; then
+  echo "✓ Installed: $(syncthing --version 2>/dev/null | head -1)"
+else
+  echo "✗ Not installed."
+  echo "  → Run: bash deploy/syncthing/install.sh"
+  exit 1
+fi
+
+# ── Device ID ───────────────────────────────────────────────
+DEVICE_ID=$(syncthing --device-id 2>/dev/null || true)
+if [ -n "$DEVICE_ID" ]; then
+  echo "✓ Device ID: $DEVICE_ID"
+else
+  echo "⚠ Could not read device ID (config not yet generated?)."
+  RC=1
+fi
+
+# ── Running? ────────────────────────────────────────────────
+RUNNING=0
+if command -v systemctl >/dev/null 2>&1 && [ -d /run/systemd/system ]; then
+  if systemctl is-active --quiet "syncthing@${SVC_USER}.service" 2>/dev/null; then
+    echo "✓ Service active: syncthing@${SVC_USER}.service"
+    RUNNING=1
+  else
+    echo "✗ Service NOT active: syncthing@${SVC_USER}.service"
+    echo "  → Start: systemctl enable --now syncthing@${SVC_USER}.service"
+    RC=1
+  fi
+elif pgrep -x syncthing >/dev/null 2>&1; then
+  echo "✓ syncthing process running (non-systemd)"
+  RUNNING=1
+else
+  echo "✗ syncthing not running."
+  echo "  → Start: syncthing serve --no-browser &"
+  RC=1
+fi
+
+# ── Folders + connections (best-effort via API) ─────────────
+if [ "$RUNNING" -eq 1 ]; then
+  CFG=""
+  for c in "$HOME/.local/state/syncthing/config.xml" "$HOME/.config/syncthing/config.xml"; do
+    [ -f "$c" ] && CFG="$c" && break
+  done
+
+  if [ -n "$CFG" ]; then
+    echo ""
+    echo "── Configured folders ──"
+    grep -oE '<folder id="[^"]+"[^>]*path="[^"]+"' "$CFG" 2>/dev/null \
+      | sed -E 's/.*id="([^"]+)".*path="([^"]+)".*/  • \1  →  \2/' \
+      || echo "  (none configured yet)"
+    grep -q 'id="centaurion-wiki"' "$CFG" 2>/dev/null \
+      && echo "  ✓ centaurion-wiki folder present" \
+      || echo "  ⚠ centaurion-wiki folder NOT configured (see folder-config.md)"
+
+    # Live status via REST API if curl + apikey available
+    API_KEY=$(sed -n 's:.*<apikey>\(.*\)</apikey>.*:\1:p' "$CFG" 2>/dev/null | head -1)
+    if [ -n "$API_KEY" ] && command -v curl >/dev/null 2>&1; then
+      echo ""
+      echo "── Connections (live) ──"
+      CONN=$(curl -fsS -H "X-API-Key: $API_KEY" \
+             http://127.0.0.1:8384/rest/system/connections 2>/dev/null || true)
+      if [ -n "$CONN" ]; then
+        if command -v python3 >/dev/null 2>&1; then
+          echo "$CONN" | python3 -c '
+import sys, json
+try:
+    d = json.load(sys.stdin).get("connections", {})
+except Exception:
+    sys.exit(0)
+if not d:
+    print("  (no remote devices configured)")
+for dev, info in d.items():
+    state = "connected" if info.get("connected") else "disconnected"
+    print(f"  • {dev[:7]}…  {state}  {info.get(\"address\",\"\")}")
+' 2>/dev/null || echo "  (could not parse connection JSON)"
+        else
+          echo "  (install python3 for a parsed view; raw API reachable)"
+        fi
+      else
+        echo "  (API not reachable on 127.0.0.1:8384 yet)"
+      fi
+    fi
+  else
+    echo ""
+    echo "⚠ No config.xml found — run install.sh / 'syncthing generate' first."
+    RC=1
+  fi
+fi
+
+echo ""
+if [ "$RC" -eq 0 ]; then
+  echo "═══ OK ═══"
+else
+  echo "═══ Action needed (see above + README RUNBOOK) ═══"
+fi
+exit "$RC"


### PR DESCRIPTION
## PT-7a — Syncthing scaffold for VPS1 ↔ VPS2 wiki sync

Phase 9 / PT-7 infra. Adds a **deployable scaffold + runbook** for P2P sync of the
wiki content under `docs/` between **VPS1 (187.124.45.132)** and **VPS2 / container
host (srv1514399)**. This is a scaffold — it was authored on srv1514399, which
cannot reach or configure VPS1, so nothing was activated. Activation is a two-host
handshake the operator runs on each host.

### What's added (`deploy/syncthing/`)
- **`README.md`** — topology + a 7-step RUNBOOK (install → device IDs → add remote
  device on both → share folder → send/receive → verify), with exact GUI and
  CLI/API commands.
- **`install.sh`** — idempotent install via the official Syncthing apt repo +
  per-user systemd service (`syncthing@<user>`, lingering enabled); prints the
  host's device ID and the next step. Every step guarded for safe re-runs.
- **`folder-config.md`** — the shared-folder definition both hosts configure
  identically: folder ID `centaurion-wiki`, path `~/Centaurion/docs`, type
  `Send & Receive`, with `config.xml` fragment, CLI equivalent, and `.stignore`.
- **`verify.sh`** — read-only status check (installed? running? device ID? folder +
  live connections), degrades gracefully when Syncthing is absent (verified on this
  host — exits 1, no mutation).

Also updates `.planning/ROADMAP.md` under PT-7 noting the scaffold was added and
that activation needs a run on each host. **PT-7 checkbox left unchecked** — not
done until both hosts are paired and "Up to Date".

### Validation done
- `bash -n` clean on both scripts.
- `verify.sh` run on srv1514399 (syncthing not installed) → reports cleanly, exit 1.
- No host mutation; `install.sh` not run.

### Manual steps still required (operator, both hosts)
1. Run `install.sh` on VPS1 (187.124.45.132) — not installed there.
2. Run `install.sh` on VPS2 (srv1514399) — not installed (`which syncthing` empty).
3. Exchange device IDs and add each as a remote device on the other host.
4. Share + accept the `centaurion-wiki` folder (`~/Centaurion/docs`, Send & Receive).
5. Run the Step 7 round-trip probe; confirm "Up to Date" on both, then check PT-7.

> Note: `deploy/README.md` lists VPS1 as `148.230.117.105`; this scaffold uses the
> task-specified `187.124.45.132`. Operator should confirm the correct VPS1 IP at
> activation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
