### PR TITLE
feat(dashboard): PT-3 surface live system status in the dashboard UI

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from 'react'
-import { 
-  BrainCircuit, 
-  Activity, 
-  CheckCircle, 
+import {
+  BrainCircuit,
+  Activity,
+  CheckCircle,
   AlertTriangle,
-  TrendingUp,
   GitBranch,
-  Server
+  Server,
+  Cpu
 } from 'lucide-react'
 
 interface DashboardStats {
@@ -23,41 +23,97 @@ interface DashboardStats {
   }>
 }
 
+interface LiveStatus {
+  source: string
+  phase: number | null
+  dev_loop: {
+    status: string | null
+    date: string | null
+    tests_remaining: number | null
+    last_run: string | null
+  }
+  routing_decisions: number
+  ratings_count: number
+  generated_at: string
+}
+
+interface HealthStatus {
+  status: string
+  services: Array<{
+    name: string
+    status: string
+    detail?: string
+    last_run?: string
+  }>
+  last_check: string
+}
+
 const mockStats: DashboardStats = {
-  total_operations: 127,
-  active_operations: 3,
-  completed_today: 12,
-  success_rate: 94.5,
-  system_health: 98,
-  active_pipelines: 2,
-  recent_activity: [
-    { type: 'operation', message: 'Market Analysis completed', time: '10m ago' },
-    { type: 'pipeline', message: 'Production Deploy succeeded', time: '2h ago' },
-    { type: 'system', message: 'Health check passed', time: '5m ago' }
-  ]
+  total_operations: 0,
+  active_operations: 0,
+  completed_today: 0,
+  success_rate: 0,
+  system_health: 0,
+  active_pipelines: 0,
+  recent_activity: []
+}
+
+// Map a backend service/health status string to a status-badge color class.
+function badgeClass(status: string): string {
+  switch (status) {
+    case 'operational':
+    case 'configured':
+      return 'success'
+    case 'progressing':
+    case 'running':
+    case 'in_progress':
+      return 'running'
+    case 'unconfigured':
+    case 'unknown':
+    case 'degraded':
+      return 'queued'
+    case 'failed':
+    case 'error':
+      return 'failed'
+    default:
+      return 'queued'
+  }
 }
 
 export default function Dashboard() {
   const [stats, setStats] = useState<DashboardStats | null>(null)
-  
+  const [live, setLive] = useState<LiveStatus | null>(null)
+  const [health, setHealth] = useState<HealthStatus | null>(null)
+
   useEffect(() => {
     fetch('/api/dashboard/stats')
       .then(res => res.json())
       .then(data => setStats(data))
       .catch(() => setStats(mockStats))
+
+    fetch('/api/status/live')
+      .then(res => res.json())
+      .then(data => setLive(data))
+      .catch(() => setLive(null))
+
+    fetch('/api/cicd/health')
+      .then(res => res.json())
+      .then(data => setHealth(data))
+      .catch(() => setHealth(null))
   }, [])
-  
+
   const displayStats = stats || mockStats
-  
+
   const getActivityIcon = (type: string) => {
     switch (type) {
-      case 'operation': return BrainCircuit
+      case 'operation':
+      case 'routing': return BrainCircuit
       case 'pipeline': return GitBranch
       case 'system': return Server
       default: return Activity
     }
   }
-  
+
   return (
     <>
       <div className="dashboard-grid">
@@ -66,13 +122,13 @@ export default function Dashboard() {
             <BrainCircuit size={24} />
           </div>
           <div className="stat-value">{displayStats.total_operations}</div>
-          <div className="stat-label">Total Operations</div>
+          <div className="stat-label">Routing Decisions</div>
           <div className="stat-trend up">
-            <TrendingUp size={14} />
-            <span>+12% this week</span>
+            <Activity size={14} />
+            <span>logged total</span>
           </div>
         </div>
-        
+
         <div className="stat-card">
           <div className="stat-icon">
             <Activity size={24} />
@@ -80,23 +136,23 @@ export default function Dashboard() {
           <div className="stat-value">{displayStats.active_operations}</div>
           <div className="stat-label">Active Operations</div>
           <div className="stat-trend up">
-            <TrendingUp size={14} />
-            <span>Running now</span>
+            <Cpu size={14} />
+            <span>{displayStats.active_operations > 0 ? 'dev loop running' : 'idle'}</span>
           </div>
         </div>
-        
+
         <div className="stat-card">
           <div className="stat-icon">
             <CheckCircle size={24} />
           </div>
-          <div className="stat-value">{displayStats.completed_today}</div>
-          <div className="stat-label">Completed Today</div>
+          <div className="stat-value">{displayStats.success_rate}%</div>
+          <div className="stat-label">Task Success Rate</div>
           <div className="stat-trend up">
-            <TrendingUp size={14} />
-            <span>+3 from yesterday</span>
+            <CheckCircle size={14} />
+            <span>{displayStats.completed_today} rated tasks</span>
           </div>
         </div>
-        
+
         <div className="stat-card">
           <div className="stat-icon">
             <AlertTriangle size={24} />
@@ -104,12 +160,12 @@ export default function Dashboard() {
           <div className="stat-value">{displayStats.system_health}%</div>
           <div className="stat-label">System Health</div>
           <div className="stat-trend up">
-            <TrendingUp size={14} />
-            <span>Optimal</span>
+            <Server size={14} />
+            <span>{displayStats.active_pipelines} pipelines</span>
           </div>
         </div>
       </div>
-      
+
       <div className="two-col-grid">
         <div className="card">
           <div className="card-header">
@@ -117,10 +173,17 @@ export default function Dashboard() {
               <Activity className="card-title-icon" size={20} />
               Recent Activity
             </h3>
-            <button className="btn btn-ghost btn-sm">View All</button>
           </div>
           <div className="card-body">
             <div className="activity-list">
+              {displayStats.recent_activity.length === 0 && (
+                <div className="activity-item">
+                  <div className="activity-content">
+                    <div className="activity-title">No recent activity</div>
+                    <div className="activity-time">waiting on the next routing decision</div>
+                  </div>
+                </div>
+              )}
               {displayStats.recent_activity.map((activity, index) => {
                 const Icon = getActivityIcon(activity.type)
                 return (
@@ -138,37 +201,60 @@ export default function Dashboard() {
             </div>
           </div>
         </div>
-        
+
+        {/* PT-3: live System Status driven by /api/status/live + /api/cicd/health */}
         <div className="card">
           <div className="card-header">
             <h3 className="card-title">
-              <GitBranch className="card-title-icon" size={20} />
-              Pipeline Status
+              <Server className="card-title-icon" size={20} />
+              System Status
             </h3>
-            <button className="btn btn-ghost btn-sm">Manage</button>
+            {live && (
+              <span className={`status-badge ${badgeClass(health?.status || 'unknown')}`}>
+                {health?.status || (live.source === 'live' ? 'live' : 'offline')}
+              </span>
+            )}
           </div>
           <div className="card-body">
+            {live && (
+              <div className="activity-item">
+                <div className="activity-icon system">
+                  <Cpu size={18} />
+                </div>
+                <div className="activity-content">
+                  <div className="activity-title">
+                    Phase {live.phase ?? '—'} · dev loop {live.dev_loop.status ?? 'unknown'}
+                  </div>
+                  <div className="activity-time">
+                    {live.dev_loop.tests_remaining ?? '—'} checks remaining ·
+                    {' '}{live.routing_decisions} decisions · {live.ratings_count} ratings
+                  </div>
+                </div>
+              </div>
+            )}
             <div className="activity-list">
-              <div className="activity-item">
-                <div className="activity-icon pipeline">
-                  <GitBranch size={18} />
+              {(health?.services ?? []).map((svc, index) => (
+                <div key={index} className="activity-item">
+                  <div className="activity-icon system">
+                    <Server size={18} />
+                  </div>
+                  <div className="activity-content">
+                    <div className="activity-title">{svc.name}</div>
+                    {svc.detail && <div className="activity-time">{svc.detail}</div>}
+                  </div>
+                  <span className={`status-badge ${badgeClass(svc.status)}`}>
+                    {svc.status}
+                  </span>
                 </div>
-                <div className="activity-content">
-                  <div className="activity-title">Production Deploy</div>
-                  <div className="activity-time">Last run: 2 hours ago • 4m 32s</div>
+              ))}
+              {!health && !live && (
+                <div className="activity-item">
+                  <div className="activity-content">
+                    <div className="activity-title">System status unavailable</div>
+                    <div className="activity-time">backend unreachable</div>
+                  </div>
                 </div>
-                <span className="status-badge success">Success</span>
-              </div>
-              <div className="activity-item">
-                <div className="activity-icon pipeline">
-                  <GitBranch size={18} />
-                </div>
-                <div className="activity-content">
-                  <div className="activity-title">Staging Deploy</div>
-                  <div className="activity-time">Running now...</div>
-                </div>
-                <span className="status-badge running">Running</span>
-              </div>
+              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
Completes **PT-3**. The dashboard previously consumed only `/api/dashboard/stats` and rendered a hardcoded "Pipeline Status" card plus invented trend strings ("+12% this week", "+3 from yesterday"). This wires the real backend signals into the UI.

## Changes (`frontend/src/pages/Dashboard.tsx`)
- **New live "System Status" panel** (replaces the static Pipeline card) driven by `/api/status/live` + `/api/cicd/health`: phase, dev-loop status + checks-remaining, routing-decision/rating counts, and per-component health (Dashboard API, Dev Loop, Routing Gate, Supermemory) with color-coded status badges.
- **Stat cards now honest**: Routing Decisions / Active Operations / Task Success Rate / System Health (with pipeline count) — no more fabricated week-over-week deltas.
- Graceful empty/offline states (no activity → friendly message; backend unreachable → "system status unavailable").

## Verification
`npm run build` (tsc + vite) passes clean — 1465 modules, no type errors.

Next: PT-4 (make the data live rather than a build-time snapshot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)