### PR TITLE
feat(dashboard): PT-5 retire market/intelligence mock (honest real data)

### DIFF
--- a/backend/api/live_data.py
+++ b/backend/api/live_data.py
@@ -346,6 +346,105 @@ def get_pipelines() -> dict:
     return {"pipelines": pipelines, "total": len(pipelines)}
 
 
+def _sa_scan_state() -> dict:
+    """Genuine SA Lens scan state if a scan file is present on disk, else {}.
+
+    The SA-scan skill (skills/sa-scan) interfaces with the external
+    situational-awareness-lens repo; when a scan run lands committed state here,
+    surface it. We probe the conventional locations and never fabricate a result
+    if none exists.
+    """
+    for rel in (
+        "memory/state/sa-scan.json",
+        "memory/state/market-intelligence.json",
+        "memory/state/work/sa-scan.json",
+    ):
+        data = _read_json(rel)
+        if data:
+            return data
+    return {}
+
+
+def _tracked_tickers() -> list:
+    """Real tracked tickers from on-disk scan state — never invented.
+
+    Prefers a committed scan file's ticker list; otherwise empty. The skill doc
+    says "18 tickers" but defers the concrete list to the external repo, so we do
+    NOT hardcode symbols here — an empty list is the honest answer until a scan
+    file lands.
+    """
+    scan = _sa_scan_state()
+    tickers = scan.get("tracked_tickers") or scan.get("tickers")
+    if isinstance(tickers, list):
+        return [str(t) for t in tickers if t]
+    return []
+
+
+def get_market_intelligence() -> dict:
+    """Honest market intelligence — real SA-scan state if present, else unconfigured.
+
+    There is NO live market data feed wired into this deployment (no price API key
+    is embedded). Rather than fabricate bullish/bearish sentiment and percentages,
+    this returns a truthful shape: if a genuine SA Lens scan file exists on disk we
+    surface its sectors/tickers; otherwise status="unconfigured" with empty data.
+
+    The frontend (frontend/src/pages/MarketIntelligence.tsx) renders sectors,
+    trends, and competitors, so those keys are always present (empty when there is
+    no real data) to keep the page from crashing.
+    """
+    scan = _sa_scan_state()
+    tracked = _tracked_tickers()
+
+    if scan:
+        # A real scan landed — surface only what it actually contains, defaulting
+        # any missing collection to empty rather than inventing it.
+        sectors = scan.get("sectors") if isinstance(scan.get("sectors"), list) else []
+        trends = scan.get("trends") if isinstance(scan.get("trends"), list) else []
+        competitors = (
+            scan.get("competitors")
+            if isinstance(scan.get("competitors"), list)
+            else []
+        )
+        return {
+            "status": "live",
+            "message": "Situational Awareness scan",
+            "sectors": sectors,
+            "trends": trends,
+            "competitors": competitors,
+            "tracked_tickers": tracked,
+            "generated_at": scan.get("generated_at")
+            or scan.get("timestamp")
+            or datetime.now(timezone.utc).isoformat(),
+            "source": "sa-lens",
+        }
+
+    return {
+        "status": "unconfigured",
+        "message": "No live market feed connected",
+        "sectors": [],
+        "trends": [],
+        "competitors": [],
+        "tracked_tickers": tracked,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "source": "none",
+    }
+
+
+def generate_report(request: dict) -> dict:
+    """Honest 'not configured' report response — no fabricated report is produced.
+
+    Report generation needs a live market/research backend that is not wired into
+    this deployment, so we return a truthful unconfigured status instead of faking
+    a "generating" job that will never complete.
+    """
+    return {
+        "status": "unconfigured",
+        "message": "Report generation is not configured — no live data backend connected",
+        "type": str((request or {}).get("type", "summary")),
+        "source": "none",
+    }
+
+
 def get_settings() -> dict:
     """Real configuration summary — repo identity + memory service status.
 

--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -2,8 +2,6 @@ from fastapi import APIRouter
 from api.mock_data import (
     create_ai_operation,
     get_operation_by_id,
-    get_market_intelligence,
-    generate_report,
     trigger_pipeline,
     update_settings
 )
@@ -13,6 +11,8 @@ from api.live_data import (
     get_health_status,
     get_live_status,
     get_ai_operations,
+    get_market_intelligence,
+    generate_report,
     get_pipelines,
     get_settings,
 )

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -5,6 +5,7 @@ fastapi + httpx; the suite is skipped cleanly if those are not installed so it
 never blocks the lightweight smoke tests.
 """
 
+import json
 import sys
 from pathlib import Path
 
@@ -130,6 +131,57 @@ def test_settings_are_live_not_mock():
     serialized = json.dumps(data)
     assert "${" not in serialized, "no env-ref placeholders leaked"
     assert "SUPERMEMORY_API_KEY" not in serialized
+
+
+# ---- PT-5: market/intelligence is honest real data, not the mock fixture ----
+
+# Old mock fixture values — their absence proves we no longer fabricate sentiment.
+_MOCK_SECTOR_NAMES = {"Technology", "Healthcare", "Finance", "Energy"}
+_MOCK_TREND_TOPICS = {"AI Automation", "Cloud Computing", "Cybersecurity"}
+_MOCK_COMPETITORS = {"TechCorp Inc", "DataSystems", "CloudNine"}
+
+
+def test_market_intelligence_is_live_not_mock():
+    resp = client.get("/api/market/intelligence")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, dict)
+    # Frontend (MarketIntelligence.tsx) renders these collections — must be present.
+    for key in ("status", "sectors", "trends", "competitors", "tracked_tickers", "source"):
+        assert key in data, f"missing {key}"
+    assert isinstance(data["sectors"], list)
+    assert isinstance(data["trends"], list)
+    assert isinstance(data["competitors"], list)
+    assert isinstance(data["tracked_tickers"], list)
+
+    # No fabricated sentiment/percentages from the old mock fixture.
+    sector_names = {s.get("name") for s in data["sectors"] if isinstance(s, dict)}
+    assert sector_names.isdisjoint(_MOCK_SECTOR_NAMES), "must not return mock sectors"
+    trend_topics = {t.get("topic") for t in data["trends"] if isinstance(t, dict)}
+    assert trend_topics.isdisjoint(_MOCK_TREND_TOPICS), "must not return mock trends"
+    comp_names = {c.get("name") for c in data["competitors"] if isinstance(c, dict)}
+    assert comp_names.isdisjoint(_MOCK_COMPETITORS), "must not return mock competitors"
+
+    serialized = json.dumps(data)
+    assert '"bullish"' not in serialized, "no fabricated bullish sentiment"
+    assert '"bearish"' not in serialized, "no fabricated bearish sentiment"
+    assert "2.4" not in serialized, "no fabricated mock percentage"
+
+    # With no SA-scan file on disk, the honest answer is the unconfigured shape.
+    assert data["status"] == "unconfigured"
+    assert data["source"] == "none"
+    assert data["sectors"] == []
+
+
+def test_market_generate_is_honest_not_fake():
+    resp = client.post("/api/market/generate", json={"type": "summary"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, dict)
+    # No fake "generating" job — honest unconfigured status.
+    assert data["status"] == "unconfigured"
+    assert data["source"] == "none"
+    assert data["type"] == "summary"
 
 
 # ---- PT-4: live runtime fetch (GitHub raw) with local fallback ----


### PR DESCRIPTION
## PT-5: Retire the last mock endpoint

`GET /api/market/intelligence` and `POST /api/market/generate` previously returned hardcoded fixtures from `backend/api/mock_data.py` (fake "Technology bullish 2.4" sentiment). This replaces them with **honest real data** — no fabricated market numbers.

### What changed
- **`live_data.get_market_intelligence`** (new): reads a genuine SA Lens scan file (`memory/state/sa-scan.json` and fallbacks) if one is present on disk and surfaces its real sectors/trends/tickers. When no live market feed is configured (the current state — no price API key embedded), it returns a truthful shape:
  ```json
  {"status":"unconfigured","message":"No live market feed connected",
   "sectors":[],"trends":[],"competitors":[],"tracked_tickers":[],"source":"none"}
  ```
- **`live_data.generate_report`** (new): honest `unconfigured` response instead of a fake "generating" job.
- **`tracked_tickers`** is derived only from a real on-disk scan file — the SA-scan skill defers the concrete ticker list to an external repo, so nothing is hardcoded (empty until a scan lands).
- **`routes.py`** now imports `get_market_intelligence` / `generate_report` from `live_data`, not `mock_data`.
- Frontend-required keys (`sectors`/`trends`/`competitors`) are always present so `MarketIntelligence.tsx` renders without crashing.

### Tests
Extended `tests/test_backend_api.py`: asserts 200, dict shape, required keys present, and the **absence** of old mock fixture values (no `"bullish"`/`"bearish"`/`2.4`). Both GET and POST honest-shape assertions.

`CENTAURION_LIVE_FETCH=0 pytest -q` → **19 passed**.

Style matches `live_data.py` exactly (`_read_json` helpers, defensive degradation, `datetime.now(timezone.utc)`). No changes to `.planning/ROADMAP.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)