### PR TITLE
feat(security): lock down CORS + add security headers (no multi-user auth)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from api.routes import router
+from security import SecurityHeadersMiddleware, get_allowed_origins
 import os
 
 app = FastAPI(
@@ -12,13 +13,19 @@ app = FastAPI(
 
 FRONTEND_DIR = "/app/frontend/dist"
 
+# Single-operator dashboard, served same-origin. CORS is an explicit allowlist
+# (env-driven via CENTAURION_ALLOWED_ORIGINS) — never a wildcard, which is both
+# invalid and unsafe when combined with credentials. No auth/tenancy is added.
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=get_allowed_origins(),
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "PUT", "OPTIONS"],
+    allow_headers=["Authorization", "Content-Type"],
 )
+
+# Defensive security headers on every response (nosniff, frame deny, CSP, ...).
+app.add_middleware(SecurityHeadersMiddleware)
 
 app.include_router(router, prefix="/api")
 

--- a/backend/security.py
+++ b/backend/security.py
@@ -1,0 +1,75 @@
+"""Production hardening for the Centaurion FastAPI backend.
+
+Single-operator dashboard — NOT multi-user. This module deliberately does NOT
+add authentication or tenancy. It only:
+
+  1. Builds a locked-down CORS allowlist (no wildcard + credentials).
+  2. Sets defensive security headers on every response.
+
+The SPA is served same-origin from the same FastAPI app, so the dashboard does
+not need a wildcard CORS origin to function.
+"""
+
+from __future__ import annotations
+
+import os
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+# Sensible production default: the Render-hosted dashboard plus local dev origins.
+DEFAULT_ALLOWED_ORIGINS = (
+    "https://centaurion.onrender.com",
+    "http://localhost:5173",  # Vite dev server
+    "http://localhost:8000",  # local uvicorn (same-origin dev)
+)
+
+# CSP for a same-origin SPA. script-src is locked to 'self' (no inline scripts —
+# the Vite build emits external module bundles). style-src allows 'unsafe-inline'
+# because React inline style props and runtime-injected styles need it, plus the
+# Google Fonts stylesheet. Font files come from fonts.gstatic.com.
+CONTENT_SECURITY_POLICY = (
+    "default-src 'self'; "
+    "script-src 'self'; "
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
+    "font-src 'self' https://fonts.gstatic.com; "
+    "img-src 'self' data:; "
+    "connect-src 'self'; "
+    "base-uri 'self'; "
+    "form-action 'self'; "
+    "frame-ancestors 'none'; "
+    "object-src 'none'"
+)
+
+SECURITY_HEADERS = {
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+    "Referrer-Policy": "strict-origin-when-cross-origin",
+    "Content-Security-Policy": CONTENT_SECURITY_POLICY,
+    # Modern guidance: disable the legacy XSS auditor rather than enable it.
+    "X-XSS-Protection": "0",
+    # HSTS intentionally NOT set here — Render terminates TLS at its edge and
+    # manages HTTPS redirects. Setting a hard max-age from the app risks pinning
+    # the wrong policy. Documented as a deliberate omission.
+}
+
+
+def get_allowed_origins() -> list[str]:
+    """Resolve the CORS allowlist from CENTAURION_ALLOWED_ORIGINS (comma-separated).
+
+    Falls back to DEFAULT_ALLOWED_ORIGINS when the env var is unset or empty.
+    """
+    raw = os.environ.get("CENTAURION_ALLOWED_ORIGINS", "")
+    origins = [o.strip() for o in raw.split(",") if o.strip()]
+    return origins or list(DEFAULT_ALLOWED_ORIGINS)
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    """Attach defensive security headers to every response."""
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        response = await call_next(request)
+        for header, value in SECURITY_HEADERS.items():
+            response.headers.setdefault(header, value)
+        return response

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -33,6 +33,62 @@ def test_health_endpoint():
     assert resp.json()["status"] == "healthy"
 
 
+# ---- Security hardening: headers + CORS lockdown (single-operator, no auth) ----
+
+_EXPECTED_SECURITY_HEADERS = {
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "DENY",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "x-xss-protection": "0",
+}
+
+
+def _assert_security_headers(resp):
+    for header, value in _EXPECTED_SECURITY_HEADERS.items():
+        assert resp.headers.get(header) == value, f"bad/missing {header}"
+    csp = resp.headers.get("content-security-policy", "")
+    assert "default-src 'self'" in csp
+    assert "script-src 'self'" in csp
+    # HSTS deliberately not set by the app — Render terminates TLS.
+    assert "strict-transport-security" not in resp.headers
+
+
+def test_security_headers_on_health():
+    _assert_security_headers(client.get("/api/health"))
+
+
+def test_security_headers_on_root(tmp_path, monkeypatch):
+    # The SPA index is served via FileResponse; headers must still be attached.
+    # In CI the built dist lives at /app/frontend/dist (created at deploy time),
+    # so point the route at a temp index.html to exercise the served-SPA path.
+    import main
+
+    index = tmp_path / "index.html"
+    index.write_text("<!doctype html><title>t</title>")
+    monkeypatch.setattr(main, "FRONTEND_DIR", str(tmp_path))
+    resp = client.get("/")
+    assert resp.status_code == 200
+    _assert_security_headers(resp)
+
+
+def test_cors_allows_configured_origin():
+    origin = "https://centaurion.onrender.com"
+    resp = client.get("/api/health", headers={"Origin": origin})
+    assert resp.status_code == 200
+    assert resp.headers.get("access-control-allow-origin") == origin
+    # Credentials are only safe with an explicit origin, never with "*".
+    assert resp.headers.get("access-control-allow-origin") != "*"
+
+
+def test_cors_rejects_unknown_origin():
+    resp = client.get("/api/health", headers={"Origin": "https://evil.example.com"})
+    assert resp.status_code == 200  # request still served; CORS is browser-enforced
+    # A disallowed origin must NOT be echoed and must NOT receive a wildcard.
+    acao = resp.headers.get("access-control-allow-origin")
+    assert acao != "*"
+    assert acao != "https://evil.example.com"
+
+
 def test_dashboard_stats_endpoint():
     resp = client.get("/api/dashboard/stats")
     assert resp.status_code == 200


### PR DESCRIPTION
## What

Production-harden the Centaurion FastAPI backend: **CORS lockdown + security headers only**. No authentication or multi-user/tenancy added (explicitly out of scope). The single-operator dashboard keeps working — the SPA is served same-origin, so it never needed a wildcard CORS origin.

## Changes (3 files only)

- `backend/security.py` (new) — allowlist resolver + `SecurityHeadersMiddleware`.
- `backend/main.py` — wire CORS allowlist + security middleware.
- `tests/test_backend_api.py` — header + CORS assertions.

## CORS policy

- `allow_origins` now reads `CENTAURION_ALLOWED_ORIGINS` (comma-separated). Default: `https://centaurion.onrender.com`, `http://localhost:5173`, `http://localhost:8000`.
- `allow_credentials=True` with **explicit origins only** (never `*` — that combo is invalid/unsafe per the CORS spec).
- `allow_methods=["GET","POST","PUT","OPTIONS"]`, `allow_headers=["Authorization","Content-Type"]` (no wildcard headers).

## Security headers (every response)

| Header | Value |
|---|---|
| `X-Content-Type-Options` | `nosniff` |
| `X-Frame-Options` | `DENY` |
| `Referrer-Policy` | `strict-origin-when-cross-origin` |
| `X-XSS-Protection` | `0` |
| `Content-Security-Policy` | `default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; object-src 'none'` |

`script-src` is locked to `'self'` (Vite emits external module bundles). `style-src` keeps `'unsafe-inline'` for React inline styles + the Google Fonts stylesheet — verified against `frontend/index.html` / built `dist`. **HSTS intentionally not set** (Render terminates TLS at its edge).

## Verification

- `CENTAURION_LIVE_FETCH=0 pytest tests/test_backend_api.py -q` → **15 passed**.
- `bandit -r backend main.py -ll` → **No issues identified** (0 medium+, matches the blocking CI step).
- `/api/health` and all existing endpoints unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)