### PR TITLE
feat(phase-10): MemPalace conversation-export miner (stdlib, runnable)

### DIFF
--- a/deploy/mempalace/.gitignore
+++ b/deploy/mempalace/.gitignore
@@ -1,0 +1,4 @@
+# Never commit raw conversation exports or the generated extract.
+exports/*
+!exports/.gitkeep
+mempalace-extract.jsonl

--- a/deploy/mempalace/README.md
+++ b/deploy/mempalace/README.md
@@ -1,0 +1,167 @@
+# MemPalace — Claude Conversation-Export Miner (Phase 10 / Knowledge Graph)
+
+> **Status: SCAFFOLD — runnable today.** The extraction pass is real, stdlib-only,
+> and needs no API key or network. The downstream emit to Graphiti + Supermemory
+> is documented below but **intentionally not fabricated** — no live round-trip is
+> claimed.
+
+MemPalace is **Layer 3** of the memory stack: the *verbatim archive*. This piece
+is its front-end miner — it reads Claude conversation exports and turns
+decision/fact statements into a structured extract that feeds the knowledge
+graph. It is the concrete answer to the Phase 10 Definition of Done:
+
+> *"Agent answers 'When did we decide to migrate from Ontraport?' from Graphiti."*
+
+Every extracted **decision** carries a `timestamp` + `speaker` + verbatim `text`,
+so "when did we decide X?" becomes a lookup once these land as Graphiti episodes.
+
+---
+
+## 1. Where Claude exports live / how to obtain them
+
+The miner accepts any directory of `.json` / `.jsonl` files in a Claude-ish shape.
+Two common sources:
+
+| Source | How to get it |
+|--------|---------------|
+| **claude.ai data export** | claude.ai → Settings → *Account* → **Export data**. You receive a zip containing `conversations.json` (an array of conversation objects, each with a `chat_messages` / `messages` list). Unzip it into `deploy/mempalace/exports/`. |
+| **Claude Code session transcripts** | Local JSONL transcripts under `~/.claude/projects/<project>/*.jsonl`. Copy or symlink the ones you want mined into `deploy/mempalace/exports/`. |
+
+The parser is **defensive**: it handles conversation objects (`{"messages": [...]}`
+or `{"chat_messages": [...]}`), bare lists of conversations, flat lists of
+messages, single messages, and several content shapes (string, list of content
+blocks, `{text|value}` dicts). Malformed lines/files are skipped with a warning,
+not a crash.
+
+> **Privacy:** `deploy/mempalace/exports/` is **gitignored**. Raw transcripts hold
+> private content — never commit them. Only the `.gitkeep` placeholder is tracked.
+
+---
+
+## 2. Run the miner
+
+No install step. Python 3 stdlib only.
+
+```bash
+cd deploy/mempalace
+
+# See all options
+python3 mine_conversations.py --help
+
+# Dry run: parse + count + preview, write nothing
+python3 mine_conversations.py exports --dry-run
+
+# Real run: writes mempalace-extract.jsonl next to you
+python3 mine_conversations.py exports
+
+# Custom output path
+python3 mine_conversations.py /path/to/exports --out /tmp/extract.jsonl
+```
+
+Safe edge cases (both exit `0` with a friendly message, no traceback):
+
+```bash
+python3 mine_conversations.py ./does-not-exist   # missing dir
+python3 mine_conversations.py exports            # empty dir
+```
+
+---
+
+## 3. What it extracts
+
+For every message it splits the body into sentence-ish units and classifies each:
+
+- **`decision`** — contains a decision verb: `decided`, `chose`, `will use`,
+  `going with`, `switched to`, `migrated`, `migrate from`, `settled on`,
+  `picked`, `opted for`, … (full list in `mine_conversations.py`).
+- **`fact`** — contains a fact marker: `because`, `the reason`, `turns out`,
+  `note that`, `important:`, `key insight`, …
+
+Output: **`mempalace-extract.jsonl`**, one JSON object per item:
+
+```json
+{"timestamp": "2026-03-02T14:11:00Z", "source_file": "conversations.json", "type": "decision", "text": "We decided to migrate from Ontraport to GoHighLevel.", "speaker": "assistant"}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `timestamp` | message time (falls back to conversation-level time, or `null`) |
+| `source_file` | export filename the item came from |
+| `type` | `decision` or `fact` |
+| `text` | the verbatim statement (capped at 600 chars) |
+| `speaker` | `role` / `sender` / `author` (e.g. `human`, `assistant`) |
+
+This is a **recall-first** heuristic pass — it favors catching real decisions
+over precision. Tune the verb/marker lists in the script as the corpus grows.
+
+---
+
+## 4. Where the output goes (downstream — documented, not wired)
+
+`mempalace-extract.jsonl` is the hand-off into the knowledge graph. Two sinks:
+
+### a. Graphiti (primary) — `memory/graphiti.json`
+
+Each record becomes a **temporal episode**. With Graphiti's MCP/SDK wired to the
+live Neo4j on VPS1 (`bolt://…:7687`), the loop is:
+
+```text
+for record in mempalace-extract.jsonl:
+    graphiti.add_episode(
+        name=f"{record['type']}:{record['source_file']}",
+        episode_body=record['text'],
+        reference_time=record['timestamp'],   # makes "when did we decide X?" answerable
+        source_description=f"mempalace miner / speaker={record['speaker']}",
+    )
+```
+
+This is the step that satisfies the Phase 10 DoD: decisions land as
+timestamped episodes, so Graphiti can answer *"When did we first decide to
+migrate from Ontraport?"*.
+
+### b. Supermemory (secondary) — `memory/supermemory.json`
+
+Each record is also written as a **document** to the relevant container
+(`aob` / `builderbee` / `centaurion`) via `POST /v3/documents`, giving the
+real-time bus a searchable copy.
+
+> **Why not wired here:** wiring requires a live Neo4j password
+> (`NEO4J_PASSWORD`) and `SUPERMEMORY_API_KEY`, both of which live only in the
+> host `/root/Centaurion/.env` (gitignored, `600`). Per the project's
+> no-fabrication rule, the emit is left as a documented, copy-pasteable step
+> rather than a fake "verified" integration. Set those env vars on the host to
+> light it up.
+
+---
+
+## 5. How this supports Phase 10
+
+```text
+Claude exports ──▶ mine_conversations.py ──▶ mempalace-extract.jsonl
+                     (decisions + facts,            │
+                      timestamped, verbatim)        ▼
+                                          Graphiti episodes (temporal)  ──▶ "When did we decide X?"
+                                          Supermemory documents (recall)
+```
+
+The miner is the deterministic, offline bridge between raw conversation history
+and the temporal graph. It needs no keys to produce value today; the graph emit
+flips on the moment the sibling Graphiti scaffold is wired.
+
+---
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `memory/mempalace.json` | Integration descriptor (status, miner spec, downstream sinks, env refs) |
+| `deploy/mempalace/mine_conversations.py` | The miner (stdlib-only, `--help`, `--dry-run`) |
+| `deploy/mempalace/README.md` | This runbook |
+| `deploy/mempalace/exports/` | Drop Claude exports here (**gitignored** — only `.gitkeep` tracked) |
+
+## Operator step (the one thing left to go live downstream)
+
+Wire the sibling **Graphiti** scaffold (`memory/graphiti.json`) — set
+`NEO4J_PASSWORD` (and optionally `SUPERMEMORY_API_KEY`) in
+`/root/Centaurion/.env` — then run the emit loop in §4 over the extract. The
+extraction pass itself already runs with zero setup.

--- a/deploy/mempalace/exports/.gitkeep
+++ b/deploy/mempalace/exports/.gitkeep
@@ -1,0 +1,3 @@
+# Drop Claude conversation exports (.json/.jsonl) here.
+# Contents are gitignored — raw transcripts hold private content and must never be committed.
+# Only this .gitkeep is tracked.

--- a/deploy/mempalace/mine_conversations.py
+++ b/deploy/mempalace/mine_conversations.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""MemPalace conversation-export miner (Phase 10 — Knowledge Graph).
+
+Parses a directory of Claude conversation export files (.json / .jsonl),
+extracts candidate "decision" and "fact" statements with simple, transparent
+heuristics, and writes a structured ``mempalace-extract.jsonl`` — one JSON
+object per extracted item:
+
+    {"timestamp": ..., "source_file": ..., "type": ..., "text": ..., "speaker": ...}
+
+Design constraints (deliberate):
+  * STDLIB ONLY. No third-party deps. No network. No API keys.
+  * Defensive parsing — never crash on a malformed or unexpected export shape.
+  * Friendly + exit 0 on an empty or missing input directory.
+  * --help and --dry-run supported.
+
+The extract is the *input* to the downstream emit (Graphiti episodes +
+Supermemory documents). That emit is documented in README.md and is NOT
+performed here — this script does the offline, key-free extraction pass only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from typing import Any, Iterable, Iterator
+
+# --- Heuristics --------------------------------------------------------------
+# Lowercased substrings. Kept small and legible on purpose: this is a
+# recall-first first pass, not an NLP model. Tune the lists freely.
+
+DECISION_VERBS = [
+    "decided",
+    "decision",
+    "chose",
+    "choosing",
+    "will use",
+    "we'll use",
+    "going with",
+    "go with",
+    "let's go with",
+    "switched to",
+    "switch to",
+    "migrated",
+    "migrate from",
+    "migrating",
+    "settled on",
+    "picked",
+    "opted for",
+    "we should use",
+]
+
+FACT_MARKERS = [
+    "because",
+    "the reason",
+    "turns out",
+    "note that",
+    "important:",
+    "key insight",
+    "the key is",
+]
+
+# Split a message body into sentence-ish units so we capture the specific
+# statement rather than a whole paragraph.
+_SENTENCE_SPLIT = re.compile(r"(?<=[.!?])\s+|\n+")
+
+# Cap how much text we keep per extracted item (defensive against giant blobs).
+MAX_TEXT_LEN = 600
+
+
+def classify(line: str) -> str | None:
+    """Return 'decision', 'fact', or None for a single sentence/line."""
+    low = line.lower()
+    for verb in DECISION_VERBS:
+        if verb in low:
+            return "decision"
+    for marker in FACT_MARKERS:
+        if marker in low:
+            return "fact"
+    return None
+
+
+def _coerce_text(content: Any) -> str:
+    """Claude exports put message bodies in several shapes. Coerce to text.
+
+    Handles: plain string; list of content blocks ({"type":"text","text":...}
+    or {"text":...}); dict with a 'text'/'value' field; anything else -> "".
+    """
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, str):
+                parts.append(block)
+            elif isinstance(block, dict):
+                parts.append(str(block.get("text") or block.get("value") or ""))
+        return "\n".join(p for p in parts if p)
+    if isinstance(content, dict):
+        return str(content.get("text") or content.get("value") or "")
+    return ""
+
+
+def _speaker_of(msg: dict) -> str:
+    for key in ("role", "sender", "author", "speaker", "from"):
+        val = msg.get(key)
+        if isinstance(val, str) and val:
+            return val
+        if isinstance(val, dict):
+            name = val.get("role") or val.get("name")
+            if name:
+                return str(name)
+    return "unknown"
+
+
+def _timestamp_of(msg: dict, fallback: str | None) -> str | None:
+    for key in ("created_at", "timestamp", "time", "createdAt", "updated_at", "date"):
+        val = msg.get(key)
+        if val:
+            return str(val)
+    return fallback
+
+
+def _iter_messages(obj: Any) -> Iterator[dict]:
+    """Yield message-like dicts from an arbitrary export object, defensively.
+
+    Recognized shapes:
+      * {"messages": [ ... ]}                     (conversation object)
+      * {"chat_messages": [ ... ]}                (claude.ai export variant)
+      * [ {conversation}, {conversation}, ... ]   (list of conversations)
+      * [ {message}, {message}, ... ]             (flat list of messages)
+      * {message}                                 (single message)
+    """
+    if isinstance(obj, dict):
+        for key in ("messages", "chat_messages", "conversation", "turns"):
+            if isinstance(obj.get(key), list):
+                # carry conversation-level timestamp down as a fallback
+                conv_ts = _timestamp_of(obj, None)
+                for m in obj[key]:
+                    if isinstance(m, dict):
+                        if conv_ts and not _timestamp_of(m, None):
+                            m = {**m, "_conv_ts": conv_ts}
+                        yield m
+                return
+        # looks like a bare message itself?
+        if any(k in obj for k in ("role", "content", "text", "sender", "author")):
+            yield obj
+        return
+    if isinstance(obj, list):
+        for item in obj:
+            yield from _iter_messages(item)
+
+
+def _load_file(path: str) -> Iterator[Any]:
+    """Yield top-level parsed objects from a .json or .jsonl file, defensively."""
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            raw = fh.read()
+    except OSError as exc:
+        print(f"  ! skip {os.path.basename(path)}: cannot read ({exc})", file=sys.stderr)
+        return
+
+    stripped = raw.strip()
+    if not stripped:
+        return
+
+    # Try whole-file JSON first (covers .json and single-object .jsonl).
+    try:
+        yield json.loads(stripped)
+        return
+    except json.JSONDecodeError:
+        pass
+
+    # Fall back to line-delimited JSON (.jsonl).
+    ok = False
+    for lineno, line in enumerate(stripped.splitlines(), 1):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            yield json.loads(line)
+            ok = True
+        except json.JSONDecodeError:
+            print(
+                f"  ! skip malformed line {lineno} in {os.path.basename(path)}",
+                file=sys.stderr,
+            )
+    if not ok:
+        print(f"  ! {os.path.basename(path)}: no parseable JSON found", file=sys.stderr)
+
+
+def extract_from_file(path: str) -> Iterator[dict]:
+    """Yield extract records from a single export file."""
+    source = os.path.basename(path)
+    for obj in _load_file(path):
+        for msg in _iter_messages(obj):
+            text = _coerce_text(msg.get("content") if "content" in msg else msg.get("text"))
+            if not text:
+                continue
+            speaker = _speaker_of(msg)
+            ts = _timestamp_of(msg, msg.get("_conv_ts"))
+            for sentence in _SENTENCE_SPLIT.split(text):
+                sentence = sentence.strip()
+                if not sentence:
+                    continue
+                kind = classify(sentence)
+                if kind is None:
+                    continue
+                yield {
+                    "timestamp": ts,
+                    "source_file": source,
+                    "type": kind,
+                    "text": sentence[:MAX_TEXT_LEN],
+                    "speaker": speaker,
+                }
+
+
+def find_exports(directory: str) -> list[str]:
+    out = []
+    for root, _dirs, files in os.walk(directory):
+        for name in sorted(files):
+            if name.lower().endswith((".json", ".jsonl")):
+                out.append(os.path.join(root, name))
+    return sorted(out)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="mine_conversations.py",
+        description=(
+            "Mine Claude conversation exports (.json/.jsonl) into a structured "
+            "mempalace-extract.jsonl of decision/fact statements. Stdlib-only, "
+            "no network, no API keys. Safe to run on an empty/missing dir."
+        ),
+        epilog="Downstream emit to Graphiti/Supermemory is documented in README.md.",
+    )
+    parser.add_argument(
+        "input_dir",
+        nargs="?",
+        default="exports",
+        help="directory of Claude export files (default: ./exports)",
+    )
+    parser.add_argument(
+        "--out",
+        default="mempalace-extract.jsonl",
+        help="output JSONL path (default: ./mempalace-extract.jsonl)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="parse and report counts but write no output file",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    in_dir = args.input_dir
+
+    if not os.path.isdir(in_dir):
+        print(
+            f"MemPalace miner: input directory '{in_dir}' not found.\n"
+            f"  Nothing to mine. Put Claude exports (.json/.jsonl) there and re-run.\n"
+            f"  See deploy/mempalace/README.md for how to obtain exports."
+        )
+        return 0
+
+    files = find_exports(in_dir)
+    if not files:
+        print(
+            f"MemPalace miner: no .json/.jsonl exports under '{in_dir}'.\n"
+            f"  Nothing to mine. (Friendly exit.)"
+        )
+        return 0
+
+    print(f"MemPalace miner: scanning {len(files)} export file(s) under '{in_dir}'...")
+
+    records: list[dict] = []
+    for path in files:
+        n_before = len(records)
+        for rec in extract_from_file(path):
+            records.append(rec)
+        print(f"  - {os.path.basename(path)}: {len(records) - n_before} item(s)")
+
+    n_decisions = sum(1 for r in records if r["type"] == "decision")
+    n_facts = sum(1 for r in records if r["type"] == "fact")
+    print(
+        f"Extracted {len(records)} item(s): "
+        f"{n_decisions} decision, {n_facts} fact."
+    )
+
+    if args.dry_run:
+        print("--dry-run: no output written.")
+        # Show a small preview so the operator can sanity-check heuristics.
+        for rec in records[:5]:
+            print("    " + json.dumps(rec, ensure_ascii=False))
+        if len(records) > 5:
+            print(f"    ... (+{len(records) - 5} more)")
+        return 0
+
+    with open(args.out, "w", encoding="utf-8") as fh:
+        for rec in records:
+            fh.write(json.dumps(rec, ensure_ascii=False) + "\n")
+    print(f"Wrote {len(records)} record(s) -> {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/memory/mempalace.json
+++ b/memory/mempalace.json
@@ -1,18 +1,58 @@
 {
   "service": "mempalace",
-  "description": "Layer 3: Verbatim archive — raw conversation exports for exact recall",
-  "status": "planned_month_2",
+  "description": "Layer 3: Verbatim archive + conversation-export miner — parses Claude conversation exports into structured decisions/facts and emits them downstream to Graphiti (temporal graph) and Supermemory (shared bus)",
+  "status": "scaffolded",
+  "activation": "ready-to-run (extraction pass is stdlib-only, no key needed); downstream emit to Graphiti + Supermemory documented but intentionally not wired",
+  "tier": "self-hosted",
+  "purpose": "Purpose: 'When did we decide to migrate from Ontraport?' / 'Show me the raw 45-min debate about GHL migration.' Mines the exact words out of Claude transcripts and turns decision/fact statements into graph episodes.",
+  "miner": {
+    "script": "deploy/mempalace/mine_conversations.py",
+    "runtime": "python3 (stdlib only — no pip install required for the extraction pass)",
+    "input": {
+      "convention": "a directory of Claude conversation export files (.json / .jsonl)",
+      "defaultPath": "deploy/mempalace/exports/",
+      "note": "exports/ is gitignored — never commit raw transcripts; they hold private content"
+    },
+    "output": {
+      "file": "mempalace-extract.jsonl",
+      "schema": "one JSON object per item: {timestamp, source_file, type, text, speaker}",
+      "types": ["decision", "fact"]
+    },
+    "heuristics": {
+      "decision_verbs": ["decided", "chose", "will use", "going with", "switched to", "migrated", "migrate from", "let's go with", "we'll use", "settled on", "picked", "opted for"],
+      "fact_markers": ["because", "the reason", "turns out", "note that", "important:", "key insight"]
+    },
+    "flags": ["--help", "--dry-run", "--out <path>"]
+  },
   "backend": {
     "vector_store": "chromadb",
     "database": "sqlite",
     "host": "VPS 1",
-    "api_cost": "zero (self-hosted)"
+    "api_cost": "zero (self-hosted)",
+    "note": "The verbatim-archive backend (chromadb/sqlite via `pip install mempalace`) is a separate, still-planned component. The miner in this repo is the stdlib front-end that produces the structured extract; it does not depend on that backend to run."
   },
   "sources": [
-    "Claude conversation exports",
-    "Telegram conversation logs (via Nova/OpenClaw)",
-    "Agent session transcripts"
+    "Claude conversation exports (claude.ai data export, or Claude Code session transcripts)",
+    "Telegram conversation logs (via Nova/OpenClaw) — future",
+    "Agent session transcripts — future"
   ],
-  "install": "pip install mempalace",
-  "purpose": "Purpose: 'Show me the raw 45-min debate about GHL migration.' When you need the exact words, not the summary."
+  "downstream": {
+    "graphiti": {
+      "descriptor": "memory/graphiti.json",
+      "role": "primary sink — each extracted decision/fact becomes a temporal episode answering 'when did we decide X?'",
+      "status": "sibling scaffold (Neo4j live on VPS1); emit step is documented in deploy/mempalace/README.md, not yet wired"
+    },
+    "supermemory": {
+      "descriptor": "memory/supermemory.json",
+      "role": "secondary sink — extracted items written as documents to the relevant container (aob/builderbee/centaurion)",
+      "status": "bus is live; emit step documented, not yet wired"
+    }
+  },
+  "envRefs": {
+    "SUPERMEMORY_API_KEY": "env:SUPERMEMORY_API_KEY (only for the optional Supermemory emit step; extraction needs no key)",
+    "NEO4J_PASSWORD": "env:NEO4J_PASSWORD (only for the optional Graphiti emit step)",
+    "apiKeyPath": "/root/Centaurion/.env (gitignored, 600 perms)"
+  },
+  "verifiedRoundTrip": false,
+  "notes": "SCAFFOLD. The extraction pass is real and runnable today with zero dependencies — point the miner at a directory of Claude exports and it writes mempalace-extract.jsonl. The downstream emit to Graphiti/Supermemory is documented in deploy/mempalace/README.md but intentionally NOT fabricated here (no live round-trip claimed). Mirrors the documented-integration pattern of memory/infranodus.json. NO secrets in this file."
 }


### PR DESCRIPTION
## Phase 10 — MemPalace: Claude conversation-export miner

Scaffolds the **MemPalace** piece of Phase 10 (Knowledge Graph): *"MemPalace installed — Claude conversation exports mined."* An honest, runnable scaffold + runbook — **not** a fabricated integration.

### What's delivered
- **`memory/mempalace.json`** — integration descriptor (`status: "scaffolded"`), matching the `infranodus.json` style: miner spec, heuristics, downstream sinks (Graphiti primary, Supermemory secondary), env-refs. **No secrets.**
- **`deploy/mempalace/mine_conversations.py`** — a real, **stdlib-only** miner. Parses Claude exports (`.json`/`.jsonl`) defensively, extracts timestamped `decision`/`fact` statements via transparent verb/marker heuristics, writes `mempalace-extract.jsonl` (`{timestamp, source_file, type, text, speaker}`). Has `--help` and `--dry-run`. **No network, no API keys.** Exits `0` with a friendly message on empty/missing dirs.
- **`deploy/mempalace/README.md`** — runbook: where exports live & how to obtain them, how to run, what it extracts, where output goes (Graphiti episodes + Supermemory documents), and how it satisfies the Phase 10 DoD *"When did we decide X?"*.
- **`exports/` is gitignored** (raw transcripts are private) — only `.gitkeep` is tracked. The generated `mempalace-extract.jsonl` is also ignored.

### Honest scope
The **extraction pass is real and runs today** with zero dependencies. The **downstream emit** to Graphiti/Supermemory is documented (copy-pasteable loop in the README §4) but intentionally **not wired/fabricated** — it needs `NEO4J_PASSWORD` / `SUPERMEMORY_API_KEY` from the host `.env`. The sibling Graphiti scaffold (`memory/graphiti.json`) is referenced as the sink but not depended on. `.planning/ROADMAP.md` was **not** edited.

### Test run (temp fixture, NOT committed)

Fixture: a claude.ai-style `conversations.json` (with `chat_messages`, content blocks) + a Claude Code-style `session.jsonl` (with a deliberately malformed final line). Created in a `mktemp -d` dir and deleted after.

```
$ python3 mine_conversations.py "$FIX"
  ! skip malformed line 4 in session.jsonl
MemPalace miner: scanning 2 export file(s) under '/tmp/tmp.XXXX'...
  - conversations.json: 4 item(s)
  - session.jsonl: 3 item(s)
Extracted 7 item(s): 5 decision, 2 fact.
Wrote 7 record(s) -> /tmp/tmp.XXXX/mempalace-extract.jsonl
```

Output (`mempalace-extract.jsonl`):

```json
{"timestamp": "2026-03-02T14:11:00Z", "source_file": "conversations.json", "type": "decision", "text": "We decided to migrate from Ontraport to GoHighLevel.", "speaker": "assistant"}
{"timestamp": "2026-03-02T14:11:00Z", "source_file": "conversations.json", "type": "fact", "text": "The reason is cost and the unified CRM.", "speaker": "assistant"}
{"timestamp": "2026-03-02T14:13:00Z", "source_file": "conversations.json", "type": "decision", "text": "We'll use GHL's native email.", "speaker": "assistant"}
{"timestamp": "2026-03-02T14:13:00Z", "source_file": "conversations.json", "type": "fact", "text": "Note that deliverability needs a warmup.", "speaker": "assistant"}
{"timestamp": "2026-04-10T09:01:00Z", "source_file": "session.jsonl", "type": "decision", "text": "Let's go with chromadb because it's self-hosted and zero cost.", "speaker": "assistant"}
{"timestamp": "2026-04-10T09:01:00Z", "source_file": "session.jsonl", "type": "decision", "text": "I also chose sqlite for metadata.", "speaker": "assistant"}
{"timestamp": "2026-04-10T09:02:00Z", "source_file": "session.jsonl", "type": "decision", "text": "Just acknowledging, nothing decided here.", "speaker": "assistant"}
```

The "Ontraport → GoHighLevel" decision is captured with its timestamp — directly serving the DoD *"When did we decide to migrate from Ontraport?"*. The malformed JSONL line was skipped gracefully. The last item is a known recall-first false-positive (matched "decided") — the README frames the heuristics as recall-first and tunable, not precise.

Edge cases verified: `--help`, `--dry-run` (preview, no write), missing dir, and empty dir all behave and exit `0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)