### PR TITLE
feat(ops): backend observability, rate limiting, non-root Docker (no auth)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,18 @@ RUN npm install && npm run build
 
 WORKDIR /app/backend
 
+# Run as a non-root user (defense in depth). Create appuser, hand it ownership
+# of /app, then drop privileges. The app only reads its baked-in state, so a
+# non-privileged user is sufficient at runtime.
+RUN useradd --create-home --uid 10001 appuser \
+    && chown -R appuser:appuser /app
+USER appuser
+
 EXPOSE 8000
+
+# Liveness probe — hits the fast, dependency-free health endpoint. curl is
+# already installed above. Non-zero exit marks the container unhealthy.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+    CMD curl -fsS http://localhost:8000/api/health || exit 1
 
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,17 +1,28 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, JSONResponse
 from api.routes import router
 from security import SecurityHeadersMiddleware, get_allowed_origins
+from observability import RateLimitMiddleware, RequestLoggingMiddleware
 import os
+import time
+
+APP_VERSION = "1.0.0"
+
+# Captured at import time so /api/health can report process uptime cheaply,
+# without touching any external dependency.
+_START_TIME = time.monotonic()
 
 app = FastAPI(
     title="Centaurion",
     description="AI-Driven Cognitive Operating System",
-    version="1.0.0"
+    version=APP_VERSION
 )
 
 FRONTEND_DIR = "/app/frontend/dist"
+# State dir baked into the image (Dockerfile COPY memory/). The readiness probe
+# confirms the live-data backing files are present before declaring ready.
+STATE_DIR = "/app/memory"
 
 # Single-operator dashboard, served same-origin. CORS is an explicit allowlist
 # (env-driven via CENTAURION_ALLOWED_ORIGINS) — never a wildcard, which is both
@@ -27,11 +38,38 @@ app.add_middleware(
 # Defensive security headers on every response (nosniff, frame deny, CSP, ...).
 app.add_middleware(SecurityHeadersMiddleware)
 
+# Anti-abuse per-IP rate limiter (NOT auth). Exempts /api/health so keep-warm
+# pings are never throttled. Limit is env-configurable.
+app.add_middleware(RateLimitMiddleware)
+
+# Structured one-line-per-request access log to stdout (Render captures it).
+# Added last so it is the outermost middleware and times the full request.
+app.add_middleware(RequestLoggingMiddleware)
+
 app.include_router(router, prefix="/api")
 
 @app.get("/api/health")
 async def health_check():
-    return {"status": "healthy", "version": "1.0.0"}
+    # Fast, dependency-free. Reports process uptime + version for observability.
+    return {
+        "status": "healthy",
+        "version": APP_VERSION,
+        "uptime_seconds": round(time.monotonic() - _START_TIME, 2),
+    }
+
+@app.get("/api/health/ready")
+async def readiness_check():
+    # Confirms the served frontend bundle and state dir are present. Returns 503
+    # when a backing resource is missing so orchestration can hold traffic.
+    checks = {
+        "frontend_dist": os.path.isdir(FRONTEND_DIR),
+        "state_dir": os.path.isdir(STATE_DIR),
+    }
+    ready = all(checks.values())
+    return JSONResponse(
+        status_code=200 if ready else 503,
+        content={"status": "ready" if ready else "not_ready", "checks": checks},
+    )
 
 @app.get("/")
 async def serve_index():

--- a/backend/observability.py
+++ b/backend/observability.py
@@ -1,0 +1,152 @@
+"""Production observability + anti-abuse rate limiting for the Centaurion backend.
+
+Single-operator dashboard — NOT multi-user. This module deliberately does NOT
+add authentication, sessions, or tenancy. It only provides:
+
+  1. Structured request logging (one line per request to stdout).
+  2. A lightweight in-process, per-IP rate limiter (anti-abuse, NOT auth).
+
+Both are stdlib-only and dependency-free so they stay cheap on Render.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import time
+from collections import defaultdict, deque
+from threading import Lock
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+# --- Logging setup --------------------------------------------------------
+
+#: Logger name used for structured request lines.
+LOGGER_NAME = "centaurion.access"
+
+#: Paths exempt from rate limiting (keep-warm pings must never be throttled).
+RATE_LIMIT_EXEMPT_PATHS = frozenset({"/api/health"})
+
+#: Default per-IP request budget per 60s window.
+DEFAULT_RATE_LIMIT_PER_MIN = 120
+
+#: Sliding window length in seconds.
+_WINDOW_SECONDS = 60.0
+
+
+def _build_logger() -> logging.Logger:
+    """Configure a stdout logger for one-line structured request records.
+
+    Render captures stdout, so a plain StreamHandler is all we need. We avoid
+    propagating to the root logger to keep output to exactly one line/request.
+    """
+    logger = logging.getLogger(LOGGER_NAME)
+    if not logger.handlers:
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+        logger.propagate = False
+    return logger
+
+
+_logger = _build_logger()
+
+
+def get_rate_limit_per_min() -> int:
+    """Resolve the per-IP rate limit from CENTAURION_RATE_LIMIT_PER_MIN.
+
+    Falls back to DEFAULT_RATE_LIMIT_PER_MIN when unset, empty, or invalid.
+    """
+    raw = os.environ.get("CENTAURION_RATE_LIMIT_PER_MIN", "")
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_RATE_LIMIT_PER_MIN
+    return value if value > 0 else DEFAULT_RATE_LIMIT_PER_MIN
+
+
+def _client_ip(request: Request) -> str:
+    """Best-effort client IP. Honors the first hop of X-Forwarded-For (Render
+    sits behind a proxy) and falls back to the socket peer."""
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    client = request.client
+    return client.host if client else "unknown"
+
+
+class RequestLoggingMiddleware(BaseHTTPMiddleware):
+    """Log one structured line per request: method, path, status, duration_ms.
+
+    Deliberately does NOT log request/response bodies, headers, query strings,
+    or any credentials — only safe routing metadata.
+    """
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        start = time.monotonic()
+        status = 500
+        try:
+            response = await call_next(request)
+            status = response.status_code
+            return response
+        finally:
+            duration_ms = round((time.monotonic() - start) * 1000.0, 2)
+            _logger.info(
+                "method=%s path=%s status=%s duration_ms=%s",
+                request.method,
+                request.url.path,
+                status,
+                duration_ms,
+            )
+
+
+class RateLimitMiddleware(BaseHTTPMiddleware):
+    """In-process sliding-window per-IP rate limiter (anti-abuse, NOT auth).
+
+    Keyed by client IP. Exempt paths (e.g. /api/health) are never throttled so
+    keep-warm pings keep working. State is per-process and resets on restart;
+    that's acceptable for single-operator abuse protection.
+    """
+
+    def __init__(self, app, limit_per_min: int | None = None) -> None:
+        super().__init__(app)
+        self._limit = (
+            limit_per_min if limit_per_min is not None else get_rate_limit_per_min()
+        )
+        self._hits: dict[str, deque] = defaultdict(deque)
+        self._lock = Lock()
+
+    def _allow(self, ip: str, now: float) -> bool:
+        cutoff = now - _WINDOW_SECONDS
+        with self._lock:
+            bucket = self._hits[ip]
+            while bucket and bucket[0] <= cutoff:
+                bucket.popleft()
+            if len(bucket) >= self._limit:
+                return False
+            bucket.append(now)
+            return True
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        if request.url.path in RATE_LIMIT_EXEMPT_PATHS:
+            return await call_next(request)
+
+        ip = _client_ip(request)
+        if not self._allow(ip, time.monotonic()):
+            retry_after = int(_WINDOW_SECONDS)
+            return JSONResponse(
+                status_code=429,
+                content={
+                    "error": "rate_limited",
+                    "detail": (
+                        f"Rate limit exceeded ({self._limit} requests/min). "
+                        "Retry later."
+                    ),
+                },
+                headers={"Retry-After": str(retry_after)},
+            )
+        return await call_next(request)

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -1,0 +1,129 @@
+"""Tests for production hardening: rate limiting, enriched health, readiness,
+and structured request logging.
+
+Single-operator hardening — NOT auth. This suite owns the hardening surface and
+deliberately does not touch test_backend_api.py. Skipped cleanly if fastapi /
+httpx are not installed so it never blocks the lightweight smoke tests.
+
+Run: CENTAURION_LIVE_FETCH=0 /tmp/centv/bin/python -m pytest tests/test_hardening.py -q
+"""
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BACKEND_DIR = REPO_ROOT / "backend"
+
+# The backend uses package-relative imports (`from api.routes import ...`),
+# which assume `backend/` is on the path.
+sys.path.insert(0, str(BACKEND_DIR))
+
+
+def _fresh_client(monkeypatch, limit):
+    """Build a TestClient against a freshly-imported app with the given per-IP
+    rate limit. Re-importing rebuilds the middleware stack so each test gets a
+    clean limiter (its sliding-window state is per-instance)."""
+    monkeypatch.setenv("CENTAURION_RATE_LIMIT_PER_MIN", str(limit))
+    # Drop cached modules so the new env value is read when middleware is built.
+    for mod in ("main", "observability"):
+        sys.modules.pop(mod, None)
+    import observability  # noqa: F401
+    main = importlib.import_module("main")
+    return TestClient(main.app), main
+
+
+# ---- Rate limiting (anti-abuse, not auth) --------------------------------
+
+
+def test_rate_limit_returns_429_after_threshold(monkeypatch):
+    limit = 3
+    client, _ = _fresh_client(monkeypatch, limit)
+
+    # A non-exempt endpoint. First `limit` requests pass, then 429.
+    ok = [client.get("/api/dashboard/stats").status_code for _ in range(limit)]
+    assert all(code != 429 for code in ok), ok
+
+    blocked = client.get("/api/dashboard/stats")
+    assert blocked.status_code == 429
+    body = blocked.json()
+    assert body["error"] == "rate_limited"
+    assert "Retry-After" in blocked.headers
+
+
+def test_health_is_exempt_from_rate_limit(monkeypatch):
+    limit = 2
+    client, _ = _fresh_client(monkeypatch, limit)
+
+    # Far exceed the limit on /api/health — keep-warm pings must never throttle.
+    for _ in range(limit * 5):
+        resp = client.get("/api/health")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "healthy"
+
+
+# ---- Enriched health -----------------------------------------------------
+
+
+def test_health_includes_uptime_and_version(monkeypatch):
+    client, _ = _fresh_client(monkeypatch, 1000)
+    body = client.get("/api/health").json()
+    assert body["status"] == "healthy"
+    assert body["version"]
+    assert isinstance(body["uptime_seconds"], (int, float))
+    assert body["uptime_seconds"] >= 0
+
+
+# ---- Readiness probe -----------------------------------------------------
+
+
+def test_readiness_check_works(monkeypatch, tmp_path):
+    client, main = _fresh_client(monkeypatch, 1000)
+
+    # Point both checked paths at existing dirs -> ready (200).
+    monkeypatch.setattr(main, "FRONTEND_DIR", str(tmp_path))
+    monkeypatch.setattr(main, "STATE_DIR", str(tmp_path))
+    resp = client.get("/api/health/ready")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ready"
+    assert body["checks"]["frontend_dist"] is True
+    assert body["checks"]["state_dir"] is True
+
+    # Missing resource -> 503.
+    monkeypatch.setattr(main, "FRONTEND_DIR", str(tmp_path / "nope"))
+    resp = client.get("/api/health/ready")
+    assert resp.status_code == 503
+    assert resp.json()["status"] == "not_ready"
+
+
+# ---- Structured logging middleware does not break responses --------------
+
+
+def test_logging_middleware_preserves_responses(monkeypatch, caplog):
+    import logging
+
+    client, _ = _fresh_client(monkeypatch, 1000)
+
+    with caplog.at_level(logging.INFO, logger="centaurion.access"):
+        resp = client.get("/api/health")
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "healthy"
+
+    # A structured access line was emitted with the expected fields.
+    lines = [r.getMessage() for r in caplog.records]
+    assert any(
+        "method=GET" in line
+        and "path=/api/health" in line
+        and "status=200" in line
+        and "duration_ms=" in line
+        for line in lines
+    ), lines


### PR DESCRIPTION
## Summary

Single-operator production hardening for the Centaurion FastAPI backend. **No authentication / multi-user / tenancy** — explicitly out of scope. The existing CORS allowlist + `SecurityHeadersMiddleware` (prior PR) are untouched.

## What changed

**`backend/observability.py` (new)**
- **Structured request logging** — `RequestLoggingMiddleware` logs one stdout line per request: `method=… path=… status=… duration_ms=…`. Stdlib `logging`, no bodies/headers/secrets. Render captures stdout.
- **Rate limiting** — `RateLimitMiddleware`, in-process sliding-window dict keyed by client IP (honors first `X-Forwarded-For` hop). Default **120 req/min/IP**, env-configurable via `CENTAURION_RATE_LIMIT_PER_MIN`. Returns **HTTP 429** with JSON `{"error":"rate_limited", ...}` + `Retry-After`. `/api/health` is **exempt** so keep-warm pings never throttle. Anti-abuse, not auth.

**`backend/main.py`**
- Wires both middlewares (logging outermost, then rate limit).
- `/api/health` enriched with `uptime_seconds` + `version` (keeps `status:"healthy"`, stays fast/dependency-free).
- New `/api/health/ready` — confirms frontend dist + state dir present, returns **200/503**.

**`Dockerfile`**
- Non-root `appuser` (uid 10001), `chown -R /app`, `USER appuser`. Build stages intact, uvicorn on 8000.
- `HEALTHCHECK` hitting `/api/health`.

**`tests/test_hardening.py` (new)** — 429 after threshold, `/api/health` exempt, readiness 200/503, logging doesn't break responses. (`test_backend_api.py` untouched.)

## Policies

| Concern | Policy |
|---|---|
| Rate limit | 120 req/min/IP (sliding 60s window), env `CENTAURION_RATE_LIMIT_PER_MIN`; 429 JSON + `Retry-After`; `/api/health` exempt |
| Log format | `method=<M> path=<P> status=<S> duration_ms=<D>` — one stdout line/request, no bodies/secrets |
| Docker user | non-root `appuser` (uid 10001), owns `/app` |

## Verification

- `pytest tests/test_hardening.py` → **5 passed**; existing `tests/test_backend_api.py` → **17 passed** (intact).
- `bandit -r backend main.py -ll` → **No issues identified** (0 medium+).
- `docker build` + `docker run` → confirmed `whoami=appuser` (uid 10001), `/api/health` 200 with uptime, `/api/health/ready` 200, structured access lines in logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)