### PR TITLE
fix(tests): R31.1 accepts OAuth-token auth; dev loop skips R32.x host tests

### DIFF
--- a/tests/identify-next-priority.sh
+++ b/tests/identify-next-priority.sh
@@ -33,7 +33,7 @@ PHASE_SCRIPTS=(
 )
 
 # Check IDs that validate host configuration rather than repo content.
-HOST_TEST_PATTERN="${CENTAURION_HOST_TEST_PATTERN:-R31\.[0-9]+}"
+HOST_TEST_PATTERN="${CENTAURION_HOST_TEST_PATTERN:-R3[12]\.[0-9]+}"
 
 # --- Run all phases and collect results ---
 declare -a PASSES FAILS TOTALS OUTPUTS
@@ -47,7 +47,8 @@ for i in "${!PHASE_SCRIPTS[@]}"; do
   else
     OUTPUT=""
   fi
-  # Host-config checks (Phase 7 R31.x: crontab, claude auth, push rights, recent
+  # Host-config checks (Phase 7 R31.x: crontab, claude auth, push rights, recent;
+  # R32.x: docker images / systemd services on the host)
   # log) can only be fixed on the VPS host, never from inside the repo. When the
   # dev loop itself is the caller it sets CENTAURION_SKIP_HOST_TESTS=1 so those
   # failures are not handed to Claude as "the next priority".

--- a/tests/verify-production.sh
+++ b/tests/verify-production.sh
@@ -22,8 +22,20 @@ echo "═══ R31: VPS1 Services ═══"
 
 # R31.1: Claude Code is authenticated (not using a raw API key)
 if command -v claude &>/dev/null; then
+  # Headless hosts authenticate via CLAUDE_CODE_OAUTH_TOKEN (see deploy/vps1/README.md);
+  # `claude auth status` reports "none" in that mode, so check the env/env-file first.
+  ENV_FILE="${CENTAURION_ENV_FILE:-/root/.config/centaurion/env}"
+  if [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && [ -r "$ENV_FILE" ] && grep -q '^CLAUDE_CODE_OAUTH_TOKEN=sk-ant-' "$ENV_FILE"; then
+    TOKEN_SOURCE="env file $ENV_FILE"
+  elif [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
+    TOKEN_SOURCE="environment"
+  else
+    TOKEN_SOURCE=""
+  fi
   AUTH_METHOD=$(claude auth status 2>/dev/null | grep -o '"authMethod": *"[^"]*"' | sed 's/.*"authMethod": *"//;s/"//' || echo "unknown")
-  if [ "$AUTH_METHOD" = "claude.ai" ] || [ "$AUTH_METHOD" = "oauth_token" ]; then
+  if [ -n "$TOKEN_SOURCE" ]; then
+    pass "R31.1: Claude Code authenticated via OAuth token ($TOKEN_SOURCE)"
+  elif [ "$AUTH_METHOD" = "claude.ai" ] || [ "$AUTH_METHOD" = "oauth_token" ]; then
     pass "R31.1: Claude Code authenticated via subscription ($AUTH_METHOD)"
   elif [ "$AUTH_METHOD" = "none" ]; then
     fail "R31.1: Claude Code not authenticated"


### PR DESCRIPTION
Follow-up to #217 from the first token-authenticated VPS1 run (tests_fixed=1, 316/318):

- **R31.1** treated `claude auth status → none` as a failure, but headless auth via `CLAUDE_CODE_OAUTH_TOKEN` legitimately reports that. Now passes when the token is in the environment or in `/root/.config/centaurion/env`.
- **R32.x** (NanoClaw docker image / systemd) are host-level like R31.x — added to the dev loop's host-skip pattern (`R3[12]\.[0-9]+`) so the loop stops parking on them. They still run (and count) in the normal suite.

Malik still runs `bash /root/nanoclaw/container/build.sh` once on VPS1 to clear R32.4 itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)